### PR TITLE
:speech_balloon: Show how to convert xarray.DataArray to torch.Tensor

### DIFF
--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -160,6 +160,8 @@ A DataPipe describes a flow of information.
 Through a series of steps it goes,
 as one piece comes in, another might follow.
 
+### Basic iteration ♻️
+
 At the most basic level, you could iterate through the DataPipe like so:
 
 ```{code-cell}
@@ -176,12 +178,34 @@ for filename, dataarray in dp_rioxarray_zoom3:
     # Run model on this data batch
 ```
 
-For the deep learning folks though, you'll probably want to use
-[``torch.utils.data.DataLoader``](https://pytorch.org/docs/1.11/data.html#torch.utils.data.DataLoader):
+### Into a DataLoader 🏋️
+
+For the deep learning folks, you might need one extra step.
+The ``xarray.DataArray`` needs to be converted to a tensor.
+In the Pytorch world, that can happen via ``torch.as_tensor``.
 
 ```{code-cell}
-dataloader = torch.utils.data.DataLoader(dataset=dp_rioxarray_zoom3)
-dataloader
+def fn(da):
+    return torch.as_tensor(da.data)
+```
+
+Using [``torchdata.datapipes.iter.Mapper``](https://pytorch.org/data/0.4.0/generated/torchdata.datapipes.iter.Mapper.html),
+we'll apply the tensor conversion function to index 1 of the
+``(filename, dataarray)`` tuple.
+
+```{code-cell}
+dp_tensor = dp_rioxarray_zoom3.map(fn=fn, input_col=1)
+dp_tensor
+```
+
+Finally, let's put our DataPipe into a
+[``torch.utils.data.DataLoader``](https://pytorch.org/docs/1.11/data.html#torch.utils.data.DataLoader)!
+
+```{code-cell}
+dataloader = torch.utils.data.DataLoader(dataset=dp_tensor)
+for batch in dataloader:
+    filename, tensor = batch
+    print(tensor)
 ```
 
 And so it begins 🌄

--- a/zen3geo/tests/test_datapipes.py
+++ b/zen3geo/tests/test_datapipes.py
@@ -9,7 +9,8 @@ from zen3geo import RioXarrayReader
 # %%
 def test_rioxarray_reader():
     """
-    Ensure that RioXarrayReader works to read in a GeoTIFF file.
+    Ensure that RioXarrayReader works to read in a GeoTIFF file and outputs a
+    tuple made up of a filename and an xarray.DataArray object.
     """
     file_url: str = "https://github.com/GenericMappingTools/gmtserver-admin/raw/master/cache/earth_day_HD.tif"
     dp = IterableWrapper(iterable=[file_url])
@@ -19,6 +20,7 @@ def test_rioxarray_reader():
     # Using functional form (recommended)
     dp_rioxarray = dp.read_from_rioxarray()
 
+    assert len(dp_rioxarray) == 1
     it = iter(dp_rioxarray)
     filename, dataarray = next(it)
 


### PR DESCRIPTION
Now we can load `xarray.DataArray` objects into `torch.Tensor` via a DataPipe! Patches #8.

References:
- https://pytorch.org/data/0.4.0/generated/torchdata.datapipes.iter.Mapper.html
- https://wandb.ai/capecape/torchdata/reports/How-the-TorchData-API-Works-a-Tutorial-with-Code--VmlldzoxNjkwNjIz
- https://github.com/tcapelle/torchdata/blob/4a22188f0f23e2d95e988a794ee5aaec197c16c5/01_Camvid_segmentation_with_datapipes.ipynb