### PR TITLE
:lock: Patch GitHub Actions workflow permissions

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: ${{ matrix.os }} - Python ${{ matrix.python-version }}
@@ -22,11 +25,11 @@ jobs:
     steps:
       # Checkout current git repository
       - name: Checkout
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
       # Install Python
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3.1.2
+        uses: actions/setup-python@98f2ad02fd48d057ee3b4d4f66525b231c3e52b6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -15,16 +15,21 @@ on:
       - '.github/workflows/deploy-docs.yml'
       - 'docs/**'
 
+permissions:
+  contents: read
+
 # This job installs dependencies, builds the docs, and pushes it to `gh-pages`
 jobs:
   deploy-docs:
+    permissions:
+      contents: write  # for peaceiris/actions-gh-pages to push pages branch
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3.0.2
+    - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
     # Install Python
     - name: Set up Python 3.9
-      uses: actions/setup-python@v3.1.2
+      uses: actions/setup-python@98f2ad02fd48d057ee3b4d4f66525b231c3e52b6
       with:
         python-version: 3.9
 
@@ -40,7 +45,7 @@ jobs:
 
     # Push the docs's HTML to github-pages
     - name: GitHub Pages action
-      uses: peaceiris/actions-gh-pages@v3.8.0
+      uses: peaceiris/actions-gh-pages@b24891da2a683970a75ebe54633f084809cc25c0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: docs/_build/html

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,6 +10,8 @@ permissions:
 
 jobs:
   update_release_draft:
+    permissions:
+      contents: write  # for release-drafter/release-drafter to create a github release
     runs-on: ubuntu-22.04
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "main"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "main"
-      - uses: release-drafter/release-drafter@v5.20.0
+      - uses: release-drafter/release-drafter@16ba0b9e928e3a09411bc0f7902e444aff589345
         with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
           config-name: release-template.yml


### PR DESCRIPTION
To limit damage in case GITHUB_TOKEN or GitHub Actions are compromised, set the minimum token permissions and pin GitHub Actions to a full length commit SHA.

Patches #11, #3, #2

References:
- https://github.com/step-security/secure-workflows
- https://app.stepsecurity.io/