### PR TITLE
:package: Publish to TestPyPI and PyPI using GitHub Actions

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -12,9 +12,9 @@ on:
     types:
       - published
   # Runs for pull requests should be disabled other than for testing purposes
-  #pull_request:
-  #  branches:
-  #    - main
+  pull_request:
+   branches:
+     - main
 
 permissions:
   contents: read

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -43,6 +43,14 @@ jobs:
           poetry plugin add poetry-dynamic-versioning-plugin
           poetry show
 
+      - name: Fix up version string for TestPyPI
+        if: ${{ !startsWith(github.ref, 'refs/tags') }}
+        run: |
+          # Change poetry-dynamic-versioning to use metadata=false so that the
+          # local part of the version isn't included, making the version string
+          # compatible with PyPI.
+          sed --in-place "s/metadata = true/metadata = false/g" pyproject.toml
+
       - name: Build a binary wheel and a source tarball
         run: |
           poetry build -vvv

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,63 @@
+# Publish archives to PyPI and TestPyPI using GitHub Actions
+# https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+
+name: Publish to PyPI
+
+# Only run for pushes to the main branch and releases.
+on:
+  push:
+    branches:
+      - main
+  release:
+    types:
+      - published
+  # Runs for pull requests should be disabled other than for testing purposes
+  #pull_request:
+  #  branches:
+  #    - main
+
+permissions:
+  contents: read
+
+jobs:
+  publish-pypi:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+    runs-on: ubuntu-22.04
+    if: github.repository == 'weiji14/zen3geo'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          # fetch all history so that poetry-dynamic-versioning works
+          fetch-depth: 0
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@98f2ad02fd48d057ee3b4d4f66525b231c3e52b6
+        with:
+          python-version: '3.9'
+
+      - name: Install Poetry and dynamic-versioning plugin
+        run: |
+          pip install poetry==1.2.0b1
+          poetry plugin add poetry-dynamic-versioning-plugin
+          poetry show
+
+      - name: Build a binary wheel and a source tarball
+        run: |
+          poetry build -vvv
+          echo ""
+          echo "Generated files:"
+          ls -lh dist/
+
+      - name: Publish distribution 📦 to Test PyPI
+        uses: pypa/gh-action-pypi-publish@0fc90bca7acbb84292e0cff399f8579284fcfc7d
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+
+      - name: Publish distribution 📦 to PyPI
+        if: startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@0fc90bca7acbb84292e0cff399f8579284fcfc7d
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -12,9 +12,9 @@ on:
     types:
       - published
   # Runs for pull requests should be disabled other than for testing purposes
-  pull_request:
-   branches:
-     - main
+  #pull_request:
+  #  branches:
+  #    - main
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Look out, sense within, and now you must know
 
 ## Installation
 
-For now, install from source using
+To install the development version from GitHub, do:
 
     pip install git+https://github.com/weiji14/zen3geo.git
+
+Or from [TestPyPI](https://test.pypi.org/project/zen3geo):
+
+    pip install --pre --extra-index-url https://test.pypi.org/simple/ zen3geo

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,11 @@
-# ☯ *zen3geo* - The 🌏 data science library you've been waiting for
+# <center> ☯ *zen3geo* - The 🌏 data science library you've been waiting for <center>
 
 ## Installation
 
-For now, install from source using
+To install the development version from GitHub, do:
 
     pip install git+https://github.com/weiji14/zen3geo.git
+
+Or from [TestPyPI](https://test.pypi.org/project/zen3geo):
+
+    pip install --pre --extra-index-url https://test.pypi.org/simple/ zen3geo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,10 @@ docs = [
 ]
 
 [tool.poetry-dynamic-versioning]
+bump = true
 enable = true
-style = "semver"
+metadata = true
+style = "pep440"
 
 [build-system]
 requires = ["poetry>=1.2.0b1", "poetry-dynamic-versioning"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Wei Ji <23487320+weiji14@users.noreply.github.com>"]
 license = "LGPL-3.0-or-later"
 readme = "README.md"
 classifiers = [
-    "Development Status :: 1 - Planning",
+    "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
     "Topic :: Scientific/Engineering",


### PR DESCRIPTION
Building the binary wheel and source tarball packages with `poetry build` and publishing to TestPyPI and PyPI via GitHub Actions.

Need to set `TEST_PYPI_API_TOKEN` and `PYPI_API_TOKEN` secrets at https://github.com/weiji14/zen3geo/settings/secrets/actions

References:
- https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows
- https://github.com/pypa/gh-action-pypi-publish/tree/v1.5.0