### PR TITLE
:truck: Put RioXarrayReader under datapipes/rioxarray.py

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -43,4 +43,4 @@ jobs:
 
       # Run the unit tests and doctests
       - name: Test with pytest
-        run: poetry run --verbose pytest --doctest-modules
+        run: poetry run --verbose pytest --doctest-modules zen3geo/

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -36,9 +36,9 @@ jobs:
       # Install poetry package manager and dependencies from poetry.lock
       - name: Install Poetry python dependencies
         run: |
-          pip install poetry==1.2.0b1
+          pip install poetry==1.2.0b2
           poetry install
-          poetry plugin add poetry-dynamic-versioning-plugin
+          poetry self add poetry-dynamic-versioning-plugin
           poetry show
 
       # Run the unit tests and doctests

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -39,8 +39,8 @@ jobs:
 
       - name: Install Poetry and dynamic-versioning plugin
         run: |
-          pip install poetry==1.2.0b1
-          poetry plugin add poetry-dynamic-versioning-plugin
+          pip install poetry==1.2.0b2
+          poetry self add poetry-dynamic-versioning-plugin
           poetry show
 
       - name: Fix up version string for TestPyPI

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Byte-compiled / optimized / DLL files
+__pycache__/
 *.py[cod]
 
 # Distribution / packaging
@@ -8,6 +9,9 @@ dist/
 *.egg-info/
 .eggs/
 MANIFEST
+
+# Unit test / coverage reports
+.pytest_cache/
 
 # Jupyter Book
 /docs/_build/

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -113,7 +113,7 @@ cd zen3geo
 mamba create --name zen3geo python=3.9
 mamba activate
 
-pip install poetry==1.2.0b1
+pip install poetry==1.2.0b2
 poetry install
 ```
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -29,6 +29,7 @@ html:
 
 sphinx:
   config:
+    autodoc_typehints: 'description'
     html_show_copyright: false
   extra_extensions:
     - 'sphinx.ext.autodoc'

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -31,7 +31,27 @@ sphinx:
   config:
     autodoc_typehints: 'description'
     html_show_copyright: false
+    intersphinx_mapping:
+      python:
+        - 'https://docs.python.org/3/'
+        - null
+      rasterio:
+        - 'https://rasterio.readthedocs.io/en/stable/'
+        - null
+      rioxarray:
+        - 'https://corteva.github.io/rioxarray/stable/'
+        - null
+      torch:
+        - 'https://pytorch.org/docs/stable/'
+        - null
+      torchdata:
+        - 'https://pytorch.org/data/main'
+        - null
+      xarray:
+        - 'https://xarray.pydata.org/en/latest/'
+        - null
   extra_extensions:
     - 'sphinx.ext.autodoc'
+    - 'sphinx.ext.intersphinx'
     - 'sphinx.ext.napoleon'
     - 'sphinx.ext.viewcode'

--- a/docs/api.md
+++ b/docs/api.md
@@ -5,4 +5,8 @@
 ```{eval-rst}
 .. automodule:: zen3geo.datapipes
     :members:
+
+.. autoclass:: zen3geo.datapipes.RioXarrayReader
+.. autoclass:: zen3geo.datapipes.rioxarray.RioXarrayReaderIterDataPipe
+    :show-inheritance:
 ```

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -99,7 +99,7 @@ Yes, I don't know what it really means either, so here's some extra reading.
 Start by wrapping a list of URLs to the Cloud-Optimized GeoTIFF files.
 We only have 1 item so we'll use ``[url]``, but if you have more, you can do
 ``[url1, url2, url3]``, etc. Pass this iterable list into
-[`torchdata.datapipes.iter.IterableWrapper`](https://pytorch.org/data/0.4.0/generated/torchdata.datapipes.iter.IterableWrapper.html):
+{py:class}`torchdata.datapipes.iter.IterableWrapper`:
 
 ```{code-cell}
 dp = torchdata.datapipes.iter.IterableWrapper(iterable=[url])
@@ -143,9 +143,8 @@ dp_rioxarray_zoom3 = dp.read_from_rioxarray(overview_level=3)
 dp_rioxarray_zoom3
 ```
 
-Extra keyword arguments will be handled by
-[``rioxarray.open_rasterio``](https://corteva.github.io/rioxarray/stable/rioxarray.html#rioxarray-open-rasterio)
-or [``rasterio.open``](https://rasterio.readthedocs.io/en/stable/api/rasterio.html#rasterio.open).
+Extra keyword arguments will be handled by {py:func}`rioxarray.open_rasterio`
+or {py:func}`rasterio.open`.
 
 ```{note}
 Other DataPipe classes/functions can be stacked or joined to this basic GeoTIFF
@@ -181,15 +180,15 @@ for filename, dataarray in dp_rioxarray_zoom3:
 ### Into a DataLoader 🏋️
 
 For the deep learning folks, you might need one extra step.
-The ``xarray.DataArray`` needs to be converted to a tensor.
-In the Pytorch world, that can happen via ``torch.as_tensor``.
+The {py:class}``xarray.DataArray`` needs to be converted to a tensor.
+In the Pytorch world, that can happen via {py:func}``torch.as_tensor``.
 
 ```{code-cell}
 def fn(da):
     return torch.as_tensor(da.data)
 ```
 
-Using [``torchdata.datapipes.iter.Mapper``](https://pytorch.org/data/0.4.0/generated/torchdata.datapipes.iter.Mapper.html),
+Using {py:class}`torchdata.datapipes.iter.Mapper`,
 we'll apply the tensor conversion function to index 1 of the
 ``(filename, dataarray)`` tuple.
 
@@ -198,8 +197,7 @@ dp_tensor = dp_rioxarray_zoom3.map(fn=fn, input_col=1)
 dp_tensor
 ```
 
-Finally, let's put our DataPipe into a
-[``torch.utils.data.DataLoader``](https://pytorch.org/docs/1.11/data.html#torch.utils.data.DataLoader)!
+Finally, let's put our DataPipe into a {py:class}`torch.utils.data.DataLoader`!
 
 ```{code-cell}
 dataloader = torch.utils.data.DataLoader(dataset=dp_tensor)

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -111,16 +111,16 @@ Now to apply some more transformations/functions on it.
 
 ### Read using RioXarrayReader 🌐
 
-This is where ``zen3geo`` comes in. We'll be using the
-{py:class}`zen3geo.datapipes.RioXarrayReaderIterDataPipe` class, or rather,
-the short alias  ``zen3geo.RioXarrayReader``.
+This is where ☯ ``zen3geo`` comes in. We'll be using the
+{py:class}`zen3geo.datapipes.rioxarray.RioXarrayReaderIterDataPipe` class, or
+rather, the short alias {py:class}`zen3geo.datapipes.RioXarrayReader`.
 
 Confusingly, there are two ways or forms of applying ``RioXarrayReader``,
 a class-based method and a functional method.
 
 ```{code-cell}
 # Using class constructors
-dp_rioxarray = zen3geo.RioXarrayReader(source_datapipe=dp)
+dp_rioxarray = zen3geo.datapipes.RioXarrayReader(source_datapipe=dp)
 dp_rioxarray
 ```
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,7 +2,7 @@
 name = "affine"
 version = "2.3.1"
 description = "Matrices describing affine transformation of the plane."
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -13,7 +13,7 @@ test = ["pytest (>=4.6)", "pytest-cov", "pydocstyle", "flake8", "coveralls"]
 name = "alabaster"
 version = "0.7.12"
 description = "A configurable sidebar-enabled Sphinx theme"
-category = "dev"
+category = "main"
 optional = true
 python-versions = "*"
 
@@ -21,7 +21,7 @@ python-versions = "*"
 name = "anyio"
 version = "3.6.1"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.6.2"
 
@@ -38,7 +38,7 @@ trio = ["trio (>=0.16)"]
 name = "appnope"
 version = "0.1.3"
 description = "Disable App Nap on macOS >= 10.9"
-category = "dev"
+category = "main"
 optional = true
 python-versions = "*"
 
@@ -46,7 +46,7 @@ python-versions = "*"
 name = "argon2-cffi"
 version = "21.3.0"
 description = "The secure Argon2 password hashing algorithm."
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.6"
 
@@ -62,7 +62,7 @@ tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pytest"]
 name = "argon2-cffi-bindings"
 version = "21.2.0"
 description = "Low-level CFFI bindings for Argon2"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.6"
 
@@ -77,7 +77,7 @@ tests = ["pytest"]
 name = "asttokens"
 version = "2.0.5"
 description = "Annotate AST trees with source code positions"
-category = "dev"
+category = "main"
 optional = true
 python-versions = "*"
 
@@ -99,7 +99,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 name = "attrs"
 version = "21.4.0"
 description = "Classes Without Boilerplate"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -113,7 +113,7 @@ tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>
 name = "babel"
 version = "2.10.1"
 description = "Internationalization utilities"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.6"
 
@@ -124,7 +124,7 @@ pytz = ">=2015.7"
 name = "backcall"
 version = "0.2.0"
 description = "Specifications for callback functions passed in to an API"
-category = "dev"
+category = "main"
 optional = true
 python-versions = "*"
 
@@ -132,7 +132,7 @@ python-versions = "*"
 name = "beautifulsoup4"
 version = "4.11.1"
 description = "Screen-scraping library"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.6.0"
 
@@ -169,7 +169,7 @@ uvloop = ["uvloop (>=0.15.2)"]
 name = "bleach"
 version = "5.0.0"
 description = "An easy safelist-based HTML-sanitizing tool."
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.7"
 
@@ -184,7 +184,7 @@ dev = ["pip-tools (==6.5.1)", "pytest (==7.1.1)", "flake8 (==4.0.1)", "tox (==3.
 name = "certifi"
 version = "2022.5.18.1"
 description = "Python package for providing Mozilla's CA Bundle."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -192,7 +192,7 @@ python-versions = ">=3.6"
 name = "cffi"
 version = "1.15.0"
 description = "Foreign Function Interface for Python calling C code."
-category = "dev"
+category = "main"
 optional = true
 python-versions = "*"
 
@@ -203,7 +203,7 @@ pycparser = "*"
 name = "charset-normalizer"
 version = "2.0.12"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.5.0"
 
@@ -214,7 +214,7 @@ unicode_backport = ["unicodedata2"]
 name = "click"
 version = "8.1.3"
 description = "Composable command line interface toolkit"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -225,7 +225,7 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 name = "click-plugins"
 version = "1.1.1"
 description = "An extension module for click to enable registering CLI commands via setuptools entry-points."
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -239,7 +239,7 @@ dev = ["pytest (>=3.6)", "pytest-cov", "wheel", "coveralls"]
 name = "cligj"
 version = "0.7.2"
 description = "Click params for commmand line interfaces to GeoJSON"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, <4"
 
@@ -253,7 +253,7 @@ test = ["pytest-cov"]
 name = "colorama"
 version = "0.4.4"
 description = "Cross-platform colored terminal text."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -261,7 +261,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 name = "debugpy"
 version = "1.6.0"
 description = "An implementation of the Debug Adapter Protocol for Python"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.7"
 
@@ -269,7 +269,7 @@ python-versions = ">=3.7"
 name = "decorator"
 version = "5.1.1"
 description = "Decorators for Humans"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.5"
 
@@ -277,7 +277,7 @@ python-versions = ">=3.5"
 name = "defusedxml"
 version = "0.7.1"
 description = "XML bomb protection for Python stdlib modules"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -285,7 +285,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 name = "docutils"
 version = "0.17.1"
 description = "Docutils -- Python Documentation Utilities"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -293,7 +293,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 name = "entrypoints"
 version = "0.4"
 description = "Discover and load entry points from installed packages."
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.6"
 
@@ -301,7 +301,7 @@ python-versions = ">=3.6"
 name = "executing"
 version = "0.8.3"
 description = "Get the currently executing AST node of a frame, and other information"
-category = "dev"
+category = "main"
 optional = true
 python-versions = "*"
 
@@ -309,7 +309,7 @@ python-versions = "*"
 name = "fastjsonschema"
 version = "2.15.3"
 description = "Fastest Python implementation of JSON schema"
-category = "dev"
+category = "main"
 optional = true
 python-versions = "*"
 
@@ -320,7 +320,7 @@ devel = ["colorama", "jsonschema", "json-spec", "pylint", "pytest", "pytest-benc
 name = "gitdb"
 version = "4.0.9"
 description = "Git Object Database"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.6"
 
@@ -331,7 +331,7 @@ smmap = ">=3.0.1,<6"
 name = "gitpython"
 version = "3.1.27"
 description = "GitPython is a python library used to interact with Git repositories"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.7"
 
@@ -342,7 +342,7 @@ gitdb = ">=4.0.1,<5"
 name = "greenlet"
 version = "1.1.2"
 description = "Lightweight in-process concurrent programming"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
 
@@ -353,7 +353,7 @@ docs = ["sphinx"]
 name = "idna"
 version = "3.3"
 description = "Internationalized Domain Names in Applications (IDNA)"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.5"
 
@@ -361,7 +361,7 @@ python-versions = ">=3.5"
 name = "imagesize"
 version = "1.3.0"
 description = "Getting image size from png/jpeg/jpeg2000/gif file"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -369,7 +369,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 name = "importlib-metadata"
 version = "4.11.4"
 description = "Read metadata from Python packages"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.7"
 
@@ -385,7 +385,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 name = "importlib-resources"
 version = "5.7.1"
 description = "Read resources from Python packages"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.7"
 
@@ -408,7 +408,7 @@ python-versions = "*"
 name = "ipykernel"
 version = "6.13.1"
 description = "IPython Kernel for Jupyter"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.7"
 
@@ -431,7 +431,7 @@ test = ["flaky", "ipyparallel", "pre-commit", "pytest-cov", "pytest-timeout", "p
 name = "ipython"
 version = "8.4.0"
 description = "IPython: Productive Interactive Computing"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.8"
 
@@ -467,7 +467,7 @@ test_extra = ["pytest (<7.1)", "pytest-asyncio", "testpath", "curio", "matplotli
 name = "ipython-genutils"
 version = "0.2.0"
 description = "Vestigial utilities from IPython"
-category = "dev"
+category = "main"
 optional = true
 python-versions = "*"
 
@@ -475,7 +475,7 @@ python-versions = "*"
 name = "ipywidgets"
 version = "7.7.0"
 description = "IPython HTML widgets for Jupyter"
-category = "dev"
+category = "main"
 optional = true
 python-versions = "*"
 
@@ -495,7 +495,7 @@ test = ["pytest (>=3.6.0)", "pytest-cov", "mock"]
 name = "jedi"
 version = "0.18.1"
 description = "An autocompletion tool for Python that can be used for text editors."
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.6"
 
@@ -510,7 +510,7 @@ testing = ["Django (<3.1)", "colorama", "docopt", "pytest (<7.0.0)"]
 name = "jinja2"
 version = "3.1.2"
 description = "A very fast and expressive template engine."
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.7"
 
@@ -524,7 +524,7 @@ i18n = ["Babel (>=2.7)"]
 name = "jsonschema"
 version = "3.2.0"
 description = "An implementation of JSON Schema validation for Python"
-category = "dev"
+category = "main"
 optional = true
 python-versions = "*"
 
@@ -542,7 +542,7 @@ format_nongpl = ["idna", "jsonpointer (>1.13)", "webcolors", "rfc3986-validator 
 name = "jupyter-book"
 version = "0.13.0"
 description = "Build a book with Jupyter Notebooks and Sphinx."
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.7"
 
@@ -576,7 +576,7 @@ testing = ["altair", "beautifulsoup4", "beautifulsoup4", "cookiecutter", "covera
 name = "jupyter-cache"
 version = "0.4.3"
 description = "A defined interface for working with a cache of jupyter notebooks."
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.6"
 
@@ -595,9 +595,9 @@ testing = ["ipykernel", "coverage", "pytest (>=3.6,<4)", "pytest-cov", "pytest-r
 
 [[package]]
 name = "jupyter-client"
-version = "7.3.2"
+version = "7.3.3"
 description = "Jupyter protocol implementation and client libraries"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.7"
 
@@ -618,7 +618,7 @@ test = ["codecov", "coverage", "ipykernel (>=6.5)", "ipython", "mypy", "pre-comm
 name = "jupyter-core"
 version = "4.10.0"
 description = "Jupyter core package. A base package on which Jupyter projects rely."
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.7"
 
@@ -631,9 +631,9 @@ test = ["ipykernel", "pre-commit", "pytest", "pytest-cov", "pytest-timeout"]
 
 [[package]]
 name = "jupyter-server"
-version = "1.17.0"
+version = "1.17.1"
 description = "The backend—i.e. core services, APIs, and REST endpoints—to Jupyter web applications."
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.7"
 
@@ -662,7 +662,7 @@ test = ["coverage", "ipykernel", "pre-commit", "pytest-console-scripts", "pytest
 name = "jupyter-server-mathjax"
 version = "0.2.5"
 description = "MathJax resources as a Jupyter Server Extension."
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.7"
 
@@ -676,7 +676,7 @@ test = ["jupyter-server", "pytest"]
 name = "jupyter-sphinx"
 version = "0.3.2"
 description = "Jupyter Sphinx Extensions"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">= 3.6"
 
@@ -691,7 +691,7 @@ Sphinx = ">=2"
 name = "jupyterlab-pygments"
 version = "0.2.2"
 description = "Pygments theme using JupyterLab CSS variables"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.7"
 
@@ -699,7 +699,7 @@ python-versions = ">=3.7"
 name = "jupyterlab-widgets"
 version = "1.1.0"
 description = "A JupyterLab extension."
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.6"
 
@@ -707,7 +707,7 @@ python-versions = ">=3.6"
 name = "latexcodec"
 version = "2.0.1"
 description = "A lexer and codec to work with LaTeX code in Python."
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -718,7 +718,7 @@ six = ">=1.4.1"
 name = "linkify-it-py"
 version = "1.0.3"
 description = "Links recognition library with FULL unicode support."
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.6"
 
@@ -735,7 +735,7 @@ test = ["coverage", "pytest", "pytest-cov"]
 name = "markdown-it-py"
 version = "1.1.0"
 description = "Python port of markdown-it. Markdown parsing, done right!"
-category = "dev"
+category = "main"
 optional = true
 python-versions = "~=3.6"
 
@@ -754,7 +754,7 @@ testing = ["coverage", "psutil", "pytest (>=3.6,<4)", "pytest-benchmark (>=3.2,<
 name = "markupsafe"
 version = "2.1.1"
 description = "Safely add untrusted strings to HTML/XML markup."
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.7"
 
@@ -762,7 +762,7 @@ python-versions = ">=3.7"
 name = "matplotlib-inline"
 version = "0.1.3"
 description = "Inline Matplotlib backend for Jupyter"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.5"
 
@@ -773,7 +773,7 @@ traitlets = "*"
 name = "mdit-py-plugins"
 version = "0.2.8"
 description = "Collection of plugins for markdown-it-py"
-category = "dev"
+category = "main"
 optional = true
 python-versions = "~=3.6"
 
@@ -789,7 +789,7 @@ testing = ["coverage", "pytest (>=3.6,<4)", "pytest-cov", "pytest-regressions"]
 name = "mistune"
 version = "0.8.4"
 description = "The fastest markdown parser in pure Python"
-category = "dev"
+category = "main"
 optional = true
 python-versions = "*"
 
@@ -805,7 +805,7 @@ python-versions = "*"
 name = "myst-nb"
 version = "0.13.2"
 description = "A Jupyter Notebook Sphinx reader built on top of the MyST markdown parser."
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.6"
 
@@ -832,7 +832,7 @@ testing = ["coverage (<5.0)", "ipykernel (>=5.5,<6.0)", "ipython (<8)", "jupytex
 name = "myst-parser"
 version = "0.15.2"
 description = "An extended commonmark compliant parser, with bridges to docutils & sphinx."
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.6"
 
@@ -854,7 +854,7 @@ testing = ["beautifulsoup4", "coverage", "docutils (>=0.17.0,<0.18.0)", "pytest 
 name = "nbclient"
 version = "0.5.13"
 description = "A client library for executing notebooks. Formerly nbconvert's ExecutePreprocessor."
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.7.0"
 
@@ -872,7 +872,7 @@ test = ["ipython (<8.0.0)", "ipykernel", "ipywidgets (<8.0.0)", "pytest (>=4.1)"
 name = "nbconvert"
 version = "6.5.0"
 description = "Converting Jupyter Notebooks"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.7"
 
@@ -905,7 +905,7 @@ webpdf = ["pyppeteer (>=1,<1.1)"]
 name = "nbdime"
 version = "3.1.1"
 description = "Diff and merge of Jupyter Notebooks"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.6"
 
@@ -928,7 +928,7 @@ test = ["pytest (>=3.6)", "pytest-cov", "pytest-timeout", "pytest-tornado", "jup
 name = "nbformat"
 version = "5.4.0"
 description = "The Jupyter Notebook format"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.7"
 
@@ -945,15 +945,15 @@ test = ["check-manifest", "testpath", "pytest", "pre-commit"]
 name = "nest-asyncio"
 version = "1.5.5"
 description = "Patch asyncio to allow nested event loops"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.5"
 
 [[package]]
 name = "notebook"
-version = "6.4.11"
+version = "6.4.12"
 description = "A web-based notebook environment for interactive computing"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.7"
 
@@ -983,7 +983,7 @@ test = ["pytest", "coverage", "requests", "testpath", "nbval", "selenium", "pyte
 name = "numpy"
 version = "1.22.4"
 description = "NumPy is the fundamental package for array computing with Python."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.8"
 
@@ -991,7 +991,7 @@ python-versions = ">=3.8"
 name = "packaging"
 version = "21.3"
 description = "Core utilities for Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -1002,7 +1002,7 @@ pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 name = "pandas"
 version = "1.4.2"
 description = "Powerful data structures for data analysis, time series, and statistics"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.8"
 
@@ -1023,7 +1023,7 @@ test = ["hypothesis (>=5.5.3)", "pytest (>=6.0)", "pytest-xdist (>=1.31)"]
 name = "pandocfilters"
 version = "1.5.0"
 description = "Utilities for writing pandoc filters in python"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -1031,7 +1031,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 name = "parso"
 version = "0.8.3"
 description = "A Python Parser"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.6"
 
@@ -1051,7 +1051,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 name = "pexpect"
 version = "4.8.0"
 description = "Pexpect allows easy control of interactive console applications."
-category = "dev"
+category = "main"
 optional = true
 python-versions = "*"
 
@@ -1062,7 +1062,7 @@ ptyprocess = ">=0.5"
 name = "pickleshare"
 version = "0.7.5"
 description = "Tiny 'shelve'-like database with concurrency support"
-category = "dev"
+category = "main"
 optional = true
 python-versions = "*"
 
@@ -1070,7 +1070,7 @@ python-versions = "*"
 name = "planetary-computer"
 version = "0.4.6"
 description = "Planetary Computer SDK for Python"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.7"
 
@@ -1110,7 +1110,7 @@ testing = ["pytest", "pytest-benchmark"]
 name = "prometheus-client"
 version = "0.14.1"
 description = "Python client for the Prometheus monitoring system."
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.6"
 
@@ -1121,7 +1121,7 @@ twisted = ["twisted"]
 name = "prompt-toolkit"
 version = "3.0.29"
 description = "Library for building powerful interactive command lines in Python"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.6.2"
 
@@ -1132,7 +1132,7 @@ wcwidth = "*"
 name = "psutil"
 version = "5.9.1"
 description = "Cross-platform lib for process and system monitoring in Python."
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -1143,7 +1143,7 @@ test = ["ipaddress", "mock", "enum34", "pywin32", "wmi"]
 name = "ptyprocess"
 version = "0.7.0"
 description = "Run a subprocess in a pseudo terminal"
-category = "dev"
+category = "main"
 optional = true
 python-versions = "*"
 
@@ -1151,7 +1151,7 @@ python-versions = "*"
 name = "pure-eval"
 version = "0.2.2"
 description = "Safely evaluate AST nodes without side effects"
-category = "dev"
+category = "main"
 optional = true
 python-versions = "*"
 
@@ -1162,7 +1162,7 @@ tests = ["pytest"]
 name = "py"
 version = "1.11.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -1170,7 +1170,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 name = "pybtex"
 version = "0.24.0"
 description = "A BibTeX-compatible bibliography processor in Python"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*"
 
@@ -1186,7 +1186,7 @@ test = ["pytest"]
 name = "pybtex-docutils"
 version = "1.0.2"
 description = "A docutils backend for pybtex."
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.6"
 
@@ -1198,7 +1198,7 @@ pybtex = ">=0.16"
 name = "pycparser"
 version = "2.21"
 description = "C parser in Python"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -1206,7 +1206,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 name = "pydantic"
 version = "1.9.1"
 description = "Data validation and settings management using python type hints"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.6.1"
 
@@ -1222,7 +1222,7 @@ email = ["email-validator (>=1.0.3)"]
 name = "pydata-sphinx-theme"
 version = "0.8.1"
 description = "Bootstrap-based Sphinx theme from the PyData community"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.7"
 
@@ -1242,7 +1242,7 @@ dev = ["pyyaml", "pre-commit", "nox", "pydata-sphinx-theme"]
 name = "pygments"
 version = "2.12.0"
 description = "Pygments is a syntax highlighting package written in Python."
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.6"
 
@@ -1250,7 +1250,7 @@ python-versions = ">=3.6"
 name = "pyparsing"
 version = "3.0.9"
 description = "pyparsing module - Classes and methods to define and execute parsing grammars"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6.8"
 
@@ -1261,7 +1261,7 @@ diagrams = ["railroad-diagrams", "jinja2"]
 name = "pyproj"
 version = "3.3.1"
 description = "Python interface to PROJ (cartographic projections and coordinate transformations library)"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.8"
 
@@ -1272,7 +1272,7 @@ certifi = "*"
 name = "pyrsistent"
 version = "0.18.1"
 description = "Persistent/Functional/Immutable data structures"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.7"
 
@@ -1280,7 +1280,7 @@ python-versions = ">=3.7"
 name = "pystac"
 version = "1.4.0"
 description = "Python library for working with Spatiotemporal Asset Catalog (STAC)."
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.7"
 
@@ -1295,7 +1295,7 @@ validation = ["jsonschema (>=3.0)"]
 name = "pystac-client"
 version = "0.3.5"
 description = "Python library for working with Spatiotemporal Asset Catalog (STAC)."
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.7"
 
@@ -1332,7 +1332,7 @@ testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 
@@ -1343,7 +1343,7 @@ six = ">=1.5"
 name = "python-dotenv"
 version = "0.20.0"
 description = "Read key-value pairs from a .env file and set them as environment variables"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.5"
 
@@ -1354,7 +1354,7 @@ cli = ["click (>=5.0)"]
 name = "pytz"
 version = "2022.1"
 description = "World timezone definitions, modern and historical"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -1362,7 +1362,7 @@ python-versions = "*"
 name = "pywin32"
 version = "304"
 description = "Python for Window Extensions"
-category = "dev"
+category = "main"
 optional = true
 python-versions = "*"
 
@@ -1370,7 +1370,7 @@ python-versions = "*"
 name = "pywinpty"
 version = "2.0.5"
 description = "Pseudo terminal support for Windows from Python."
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.7"
 
@@ -1378,7 +1378,7 @@ python-versions = ">=3.7"
 name = "pyyaml"
 version = "6.0"
 description = "YAML parser and emitter for Python"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.6"
 
@@ -1386,7 +1386,7 @@ python-versions = ">=3.6"
 name = "pyzmq"
 version = "23.1.0"
 description = "Python bindings for 0MQ"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.6"
 
@@ -1398,7 +1398,7 @@ py = {version = "*", markers = "implementation_name == \"pypy\""}
 name = "rasterio"
 version = "1.2.10"
 description = "Fast and direct raster I/O for use with Numpy and SciPy"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -1425,7 +1425,7 @@ test = ["boto3 (>=1.2.4)", "hypothesis", "packaging", "pytest-cov (>=2.2.0)", "p
 name = "requests"
 version = "2.27.1"
 description = "Python HTTP for Humans."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
@@ -1443,7 +1443,7 @@ use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
 name = "rioxarray"
 version = "0.11.1"
 description = "geospatial xarray extension powered by rasterio"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.8"
 
@@ -1464,7 +1464,7 @@ test = ["pytest (>=3.6)", "pytest-cov", "pytest-timeout", "dask", "netcdf4"]
 name = "send2trash"
 version = "1.8.0"
 description = "Send file to trash natively under Mac OS X, Windows and Linux."
-category = "dev"
+category = "main"
 optional = true
 python-versions = "*"
 
@@ -1475,9 +1475,9 @@ win32 = ["pywin32"]
 
 [[package]]
 name = "setuptools"
-version = "62.3.2"
+version = "62.3.3"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -1490,7 +1490,7 @@ testing-integration = ["pytest", "pytest-xdist", "pytest-enabler", "virtualenv (
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
@@ -1498,7 +1498,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 name = "smmap"
 version = "5.0.0"
 description = "A pure Python implementation of a sliding window memory map manager"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.6"
 
@@ -1506,7 +1506,7 @@ python-versions = ">=3.6"
 name = "sniffio"
 version = "1.2.0"
 description = "Sniff out which async library your code is running under"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.5"
 
@@ -1514,7 +1514,7 @@ python-versions = ">=3.5"
 name = "snowballstemmer"
 version = "2.2.0"
 description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
-category = "dev"
+category = "main"
 optional = true
 python-versions = "*"
 
@@ -1522,7 +1522,7 @@ python-versions = "*"
 name = "snuggs"
 version = "1.4.7"
 description = "Snuggs are s-expressions for Numpy"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -1537,7 +1537,7 @@ test = ["pytest", "hypothesis"]
 name = "soupsieve"
 version = "2.3.2.post1"
 description = "A modern CSS selector implementation for Beautiful Soup."
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.6"
 
@@ -1545,7 +1545,7 @@ python-versions = ">=3.6"
 name = "sphinx"
 version = "4.5.0"
 description = "Python documentation generator"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.6"
 
@@ -1577,7 +1577,7 @@ test = ["pytest", "pytest-cov", "html5lib", "cython", "typed-ast"]
 name = "sphinx-book-theme"
 version = "0.3.2"
 description = "A clean book theme for scientific explanations and documentation with Sphinx"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.7"
 
@@ -1595,7 +1595,7 @@ test = ["beautifulsoup4 (>=4.6.1,<5)", "coverage", "myst_nb (>=0.13,<1.0)", "pyt
 name = "sphinx-comments"
 version = "0.0.3"
 description = "Add comments and annotation to your documentation."
-category = "dev"
+category = "main"
 optional = true
 python-versions = "*"
 
@@ -1611,7 +1611,7 @@ testing = ["beautifulsoup4", "myst-parser", "pytest", "pytest-regressions", "sph
 name = "sphinx-copybutton"
 version = "0.5.0"
 description = "Add a copy button to each of your code cells."
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.6"
 
@@ -1626,7 +1626,7 @@ rtd = ["sphinx", "ipython", "myst-nb", "sphinx-book-theme"]
 name = "sphinx-design"
 version = "0.1.0"
 description = "A sphinx extension for designing beautiful, view size responsive web components."
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.7"
 
@@ -1646,7 +1646,7 @@ theme_sbt = ["sphinx-book-theme (>=0.3.0,<0.4.0)"]
 name = "sphinx-external-toc"
 version = "0.2.4"
 description = "A sphinx extension that allows the site-map to be defined in a single YAML file."
-category = "dev"
+category = "main"
 optional = true
 python-versions = "~=3.6"
 
@@ -1665,7 +1665,7 @@ testing = ["coverage", "pytest (>=3.6,<4)", "pytest-cov", "pytest-regressions"]
 name = "sphinx-jupyterbook-latex"
 version = "0.4.6"
 description = "Latex specific features for jupyter book"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.6"
 
@@ -1683,7 +1683,7 @@ testing = ["coverage (<5.0)", "myst-nb (>=0.13,<0.14)", "pytest (>=3.6,<4)", "py
 name = "sphinx-multitoc-numbering"
 version = "0.1.3"
 description = "Supporting continuous HTML section numbering"
-category = "dev"
+category = "main"
 optional = true
 python-versions = "*"
 
@@ -1699,7 +1699,7 @@ testing = ["pytest (>=5.4,<6.0)", "pytest-cov (>=2.8,<3.0)", "coverage (<5.0)", 
 name = "sphinx-thebe"
 version = "0.1.2"
 description = "Integrate interactive code blocks into your documentation with Thebe and Binder."
-category = "dev"
+category = "main"
 optional = true
 python-versions = "*"
 
@@ -1714,7 +1714,7 @@ testing = ["matplotlib", "pytest", "pytest-regressions", "beautifulsoup4"]
 name = "sphinx-togglebutton"
 version = "0.3.1"
 description = "Toggle page content and collapse admonitions in Sphinx."
-category = "dev"
+category = "main"
 optional = true
 python-versions = "*"
 
@@ -1731,7 +1731,7 @@ sphinx = ["myst-parser", "sphinx-book-theme", "sphinx-design"]
 name = "sphinxcontrib-applehelp"
 version = "1.0.2"
 description = "sphinxcontrib-applehelp is a sphinx extension which outputs Apple help books"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.5"
 
@@ -1743,7 +1743,7 @@ test = ["pytest"]
 name = "sphinxcontrib-bibtex"
 version = "2.4.2"
 description = "Sphinx extension for BibTeX style citations."
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.6"
 
@@ -1757,7 +1757,7 @@ Sphinx = ">=2.1"
 name = "sphinxcontrib-devhelp"
 version = "1.0.2"
 description = "sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp document."
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.5"
 
@@ -1769,7 +1769,7 @@ test = ["pytest"]
 name = "sphinxcontrib-htmlhelp"
 version = "2.0.0"
 description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.6"
 
@@ -1781,7 +1781,7 @@ test = ["pytest", "html5lib"]
 name = "sphinxcontrib-jsmath"
 version = "1.0.1"
 description = "A sphinx extension which renders display math in HTML via JavaScript"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.5"
 
@@ -1792,7 +1792,7 @@ test = ["pytest", "flake8", "mypy"]
 name = "sphinxcontrib-qthelp"
 version = "1.0.3"
 description = "sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp document."
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.5"
 
@@ -1804,7 +1804,7 @@ test = ["pytest"]
 name = "sphinxcontrib-serializinghtml"
 version = "1.1.5"
 description = "sphinxcontrib-serializinghtml is a sphinx extension which outputs \"serialized\" HTML files (json and pickle)."
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.5"
 
@@ -1816,7 +1816,7 @@ test = ["pytest"]
 name = "sqlalchemy"
 version = "1.4.37"
 description = "Database Abstraction Library"
-category = "dev"
+category = "main"
 optional = true
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
 
@@ -1848,7 +1848,7 @@ sqlcipher = ["sqlcipher3-binary"]
 name = "stack-data"
 version = "0.2.0"
 description = "Extract data from python stack frames and tracebacks for informative displays"
-category = "dev"
+category = "main"
 optional = true
 python-versions = "*"
 
@@ -1864,7 +1864,7 @@ tests = ["pytest", "typeguard", "pygments", "littleutils", "cython"]
 name = "terminado"
 version = "0.15.0"
 description = "Tornado websocket backend for the Xterm.js Javascript terminal emulator library."
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.7"
 
@@ -1880,7 +1880,7 @@ test = ["pre-commit", "pytest-timeout", "pytest (>=6.0)"]
 name = "tinycss2"
 version = "1.1.1"
 description = "A tiny CSS parser"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.6"
 
@@ -1903,7 +1903,7 @@ python-versions = ">=3.7"
 name = "torch"
 version = "1.11.0"
 description = "Tensors and Dynamic neural networks in Python with strong GPU acceleration"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7.0"
 
@@ -1914,7 +1914,7 @@ typing-extensions = "*"
 name = "torchdata"
 version = "0.3.0"
 description = "Composable data loading modules for PyTorch"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -1927,7 +1927,7 @@ urllib3 = ">=1.25"
 name = "tornado"
 version = "6.1"
 description = "Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed."
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">= 3.5"
 
@@ -1935,7 +1935,7 @@ python-versions = ">= 3.5"
 name = "traitlets"
 version = "5.2.2.post1"
 description = ""
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.7"
 
@@ -1946,7 +1946,7 @@ test = ["pre-commit", "pytest"]
 name = "typing-extensions"
 version = "4.2.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -1954,7 +1954,7 @@ python-versions = ">=3.7"
 name = "uc-micro-py"
 version = "1.0.1"
 description = "Micro subset of unicode data files for linkify-it-py projects."
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.6"
 
@@ -1965,7 +1965,7 @@ test = ["coverage", "pytest", "pytest-cov"]
 name = "urllib3"
 version = "1.26.9"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 
@@ -1978,7 +1978,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 name = "wcwidth"
 version = "0.2.5"
 description = "Measures the displayed width of unicode strings in a terminal"
-category = "dev"
+category = "main"
 optional = true
 python-versions = "*"
 
@@ -1986,7 +1986,7 @@ python-versions = "*"
 name = "webencodings"
 version = "0.5.1"
 description = "Character encoding aliases for legacy web content"
-category = "dev"
+category = "main"
 optional = true
 python-versions = "*"
 
@@ -1994,7 +1994,7 @@ python-versions = "*"
 name = "websocket-client"
 version = "1.3.2"
 description = "WebSocket client for Python with low level API options"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.7"
 
@@ -2007,7 +2007,7 @@ test = ["websockets"]
 name = "wheel"
 version = "0.37.1"
 description = "A built-package format for Python"
-category = "dev"
+category = "main"
 optional = true
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
@@ -2018,7 +2018,7 @@ test = ["pytest (>=3.0.0)", "pytest-cov"]
 name = "widgetsnbextension"
 version = "3.6.0"
 description = "IPython HTML widgets for Jupyter"
-category = "dev"
+category = "main"
 optional = true
 python-versions = "*"
 
@@ -2029,7 +2029,7 @@ notebook = ">=4.4.1"
 name = "xarray"
 version = "2022.3.0"
 description = "N-D labeled arrays and datasets in Python"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.8"
 
@@ -2050,7 +2050,7 @@ viz = ["matplotlib", "seaborn", "nc-time-axis"]
 name = "zipp"
 version = "3.8.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
-category = "dev"
+category = "main"
 optional = true
 python-versions = ">=3.7"
 
@@ -2064,7 +2064,7 @@ docs = ["jupyter-book", "planetary-computer", "pystac"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "f10b2df09dab0b403616824a6f53e75d358f8d8b28afa837a33e3dcf9db8c34b"
+content-hash = "e2020f1956d1bb5210b8346a3f148e580855ba85b7e83672d68dbe2490e6978e"
 
 [metadata.files]
 affine = [
@@ -2405,16 +2405,16 @@ jupyter-cache = [
     {file = "jupyter_cache-0.4.3-py3-none-any.whl", hash = "sha256:6d5d662d81f565d18009e8dcfd3a56fb876af47eafead2a19ef0045aba8ffe3b"},
 ]
 jupyter-client = [
-    {file = "jupyter_client-7.3.2-py3-none-any.whl", hash = "sha256:be7dff1c6792a951169b514b9b66e9d7ffaba811575cf49d24b73a1ca28f014a"},
-    {file = "jupyter_client-7.3.2.tar.gz", hash = "sha256:8f92691bf2d8c670e108813a0290d93a3dc84f74fb844e915b7e587ef2fcbf44"},
+    {file = "jupyter_client-7.3.3-py3-none-any.whl", hash = "sha256:5b4f5bb9f9c3b5466ba84761312ed75f487bf3b8b0e1eeeec4bb2d0f9d855c70"},
+    {file = "jupyter_client-7.3.3.tar.gz", hash = "sha256:9e80defc0058712bf2b30327bad582f9734668aa85e90256dcba116325ce3060"},
 ]
 jupyter-core = [
     {file = "jupyter_core-4.10.0-py3-none-any.whl", hash = "sha256:e7f5212177af7ab34179690140f188aa9bf3d322d8155ed972cbded19f55b6f3"},
     {file = "jupyter_core-4.10.0.tar.gz", hash = "sha256:a6de44b16b7b31d7271130c71a6792c4040f077011961138afed5e5e73181aec"},
 ]
 jupyter-server = [
-    {file = "jupyter_server-1.17.0-py3-none-any.whl", hash = "sha256:5aa5e0945e3dbf29390cfe9c418a9af245d812ce282932ae97d0671e10c147a0"},
-    {file = "jupyter_server-1.17.0.tar.gz", hash = "sha256:7b3aa524790ab0da64f06dfe0b2af149d0a3f59aad71fdedcf1d8bae6508018c"},
+    {file = "jupyter_server-1.17.1-py3-none-any.whl", hash = "sha256:3ee6aaf3607489aecaa69a4d2ffb93faa70e89b9169772e389d7989e1cca28fd"},
+    {file = "jupyter_server-1.17.1.tar.gz", hash = "sha256:a36781656645ae17b12819a49ace377c045bf633823b3e4cd4b0c88c01e7711b"},
 ]
 jupyter-server-mathjax = [
     {file = "jupyter_server_mathjax-0.2.5-py3-none-any.whl", hash = "sha256:d165c9ff876a1c32ccf99d309b57463fae206d9b6f0f3a9fa34ed01b3b26605e"},
@@ -2531,8 +2531,8 @@ nest-asyncio = [
     {file = "nest_asyncio-1.5.5.tar.gz", hash = "sha256:e442291cd942698be619823a17a86a5759eabe1f8613084790de189fe9e16d65"},
 ]
 notebook = [
-    {file = "notebook-6.4.11-py3-none-any.whl", hash = "sha256:b4a6baf2eba21ce67a0ca11a793d1781b06b8078f34d06c710742e55f3eee505"},
-    {file = "notebook-6.4.11.tar.gz", hash = "sha256:709b1856a564fe53054796c80e17a67262071c86bfbdfa6b96aaa346113c555a"},
+    {file = "notebook-6.4.12-py3-none-any.whl", hash = "sha256:8c07a3bb7640e371f8a609bdbb2366a1976c6a2589da8ef917f761a61e3ad8b1"},
+    {file = "notebook-6.4.12.tar.gz", hash = "sha256:6268c9ec9048cff7a45405c990c29ac9ca40b0bc3ec29263d218c5e01f2b4e86"},
 ]
 numpy = [
     {file = "numpy-1.22.4-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:ba9ead61dfb5d971d77b6c131a9dbee62294a932bf6a356e48c75ae684e635b3"},
@@ -2944,8 +2944,8 @@ send2trash = [
     {file = "Send2Trash-1.8.0.tar.gz", hash = "sha256:d2c24762fd3759860a0aff155e45871447ea58d2be6bdd39b5c8f966a0c99c2d"},
 ]
 setuptools = [
-    {file = "setuptools-62.3.2-py3-none-any.whl", hash = "sha256:68e45d17c9281ba25dc0104eadd2647172b3472d9e01f911efa57965e8d51a36"},
-    {file = "setuptools-62.3.2.tar.gz", hash = "sha256:a43bdedf853c670e5fed28e5623403bad2f73cf02f9a2774e91def6bda8265a7"},
+    {file = "setuptools-62.3.3-py3-none-any.whl", hash = "sha256:d1746e7fd520e83bbe210d02fff1aa1a425ad671c7a9da7d246ec2401a087198"},
+    {file = "setuptools-62.3.3.tar.gz", hash = "sha256:e7d11f3db616cda0751372244c2ba798e8e56a28e096ec4529010b803485f3fe"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,5 +44,5 @@ metadata = true
 style = "pep440"
 
 [build-system]
-requires = ["poetry>=1.2.0b1", "poetry-dynamic-versioning"]
+requires = ["poetry>=1.2.0b2", "poetry-dynamic-versioning"]
 build-backend = "poetry.masonry.api"

--- a/zen3geo/__init__.py
+++ b/zen3geo/__init__.py
@@ -4,6 +4,6 @@ zen3geo - The 🌏 data science library you've been waiting for~
 
 from importlib.metadata import version
 
-from zen3geo.datapipes import RioXarrayReaderIterDataPipe as RioXarrayReader
+from zen3geo import datapipes
 
 __version__ = version("zen3geo")  # e.g. 0.1.2.dev3+g0ab3cd78

--- a/zen3geo/datapipes/__init__.py
+++ b/zen3geo/datapipes/__init__.py
@@ -1,0 +1,5 @@
+"""
+Iterable-style DataPipes for geospatial raster 🌈 and vector 🚏 data.
+"""
+
+from zen3geo.datapipes.rioxarray import RioXarrayReaderIterDataPipe as RioXarrayReader

--- a/zen3geo/datapipes/rioxarray.py
+++ b/zen3geo/datapipes/rioxarray.py
@@ -1,8 +1,5 @@
 """
-Iterable-style DataPipes for geospatial raster and vector data.
-
-Based on
-https://github.com/pytorch/data/blob/v0.3.0/torchdata/datapipes/iter/load/online.py#L29-L59
+DataPipes for rioxarray.
 """
 from typing import Any, Dict, Iterator, Optional, Tuple
 
@@ -19,6 +16,9 @@ class RioXarrayReaderIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
     (as long as they can be read by rioxarray and/or rasterio)
     and yields tuples of filename and xarray.DataArray objects
     (functional name: ``read_from_rioxarray``).
+
+    Based on
+    https://github.com/pytorch/data/blob/v0.3.0/torchdata/datapipes/iter/load/online.py#L29-L59
 
     Parameters
     ----------
@@ -41,7 +41,7 @@ class RioXarrayReaderIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
     Example
     -------
     >>> from torchdata.datapipes.iter import IterableWrapper
-    >>> from zen3geo import RioXarrayReader
+    >>> from zen3geo.datapipes import RioXarrayReader
     ...
     >>> # Read in GeoTIFF data using DataPipe
     >>> file_url: str = "https://github.com/GenericMappingTools/gmtserver-admin/raw/master/cache/earth_day_HD.tif"

--- a/zen3geo/datapipes/rioxarray.py
+++ b/zen3geo/datapipes/rioxarray.py
@@ -14,7 +14,7 @@ class RioXarrayReaderIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
     """
     Takes raster files (e.g. GeoTIFFs) from local disk or URLs
     (as long as they can be read by rioxarray and/or rasterio)
-    and yields tuples of filename and xarray.DataArray objects
+    and yields tuples of filename and :py:class:`xarray.DataArray` objects
     (functional name: ``read_from_rioxarray``).
 
     Based on
@@ -27,16 +27,14 @@ class RioXarrayReaderIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
         GeoTIFFs.
 
     kwargs : Optional
-        Extra keyword arguments to pass to ``rioxarray.open_rasterio`` and/or
-        ``rasterio.open``. See
-        https://corteva.github.io/rioxarray/stable/rioxarray.html#rioxarray-open-rasterio
-        and https://rasterio.readthedocs.io/en/stable/api/rasterio.html#rasterio.open
+        Extra keyword arguments to pass to :py:func:`rioxarray.open_rasterio`
+        and/or :py:func:`rasterio.open`.
 
     Yields
     ------
     stream_obj : Tuple[str, xarray.DataArray]
         A tuple consisting of the filename that was passed in, and an
-        ``xarray.DataArray`` object containing the raster data.
+        :py:class:`xarray.DataArray` object containing the raster data.
 
     Example
     -------

--- a/zen3geo/tests/test_datapipes.py
+++ b/zen3geo/tests/test_datapipes.py
@@ -3,7 +3,7 @@ Tests for datapipes.
 """
 from torchdata.datapipes.iter import IterableWrapper
 
-from zen3geo import RioXarrayReader
+from zen3geo.datapipes import RioXarrayReader
 
 
 # %%


### PR DESCRIPTION
Make it one file:one library (allow for optional dependencies later). Also some improvements to the sphinx docs using intersphinx.

TODO:
- [x] Move RioXarrayReader from datapipes.py to datapipes/rioxarray.py
- [x] Make [intersphinx](https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html) docs work

Notes while working on this PR:
- Tried to follow https://jupyterbook.org/en/stable/advanced/developers.html#api-reference-from-docstrings to use `autosummary` or `autoapi` but ran into headwinds:
  - `autosummary` requires templates to work properly as per https://stackoverflow.com/questions/2701998/sphinx-autodoc-is-not-automatic-enough/62613202#62613202, but the templates themselves are a nightmare to manage
  - `autoapi` is very tempting, but couldn't get it to work with `sphinx.ext.viewcode`, possibly due to https://github.com/readthedocs/sphinx-autoapi/issues/291, and the project at https://github.com/readthedocs/sphinx-autoapi seems a bit light on maintenance (though will revisit in a few months).

References:
- https://docs.readthedocs.io/en/stable/guides/intersphinx.html
- https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html