### PR TITLE
:art: Extra subsection for rioxarray datapipes

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -43,4 +43,4 @@ jobs:
 
       # Run the unit tests and doctests
       - name: Test with pytest
-        run: poetry run --verbose pytest --doctest-modules zen3geo/
+        run: poetry run pytest --verbose --doctest-modules zen3geo/

--- a/docs/api.md
+++ b/docs/api.md
@@ -5,7 +5,12 @@
 ```{eval-rst}
 .. automodule:: zen3geo.datapipes
     :members:
+```
 
+### Rioxarray
+
+```{eval-rst}
+.. automodule:: zen3geo.datapipes.rioxarray
 .. autoclass:: zen3geo.datapipes.RioXarrayReader
 .. autoclass:: zen3geo.datapipes.rioxarray.RioXarrayReaderIterDataPipe
     :show-inheritance:

--- a/zen3geo/datapipes/rioxarray.py
+++ b/zen3geo/datapipes/rioxarray.py
@@ -1,5 +1,5 @@
 """
-DataPipes for rioxarray.
+DataPipes for :doc:`rioxarray <rioxarray:index>`.
 """
 from typing import Any, Dict, Iterator, Optional, Tuple
 

--- a/zen3geo/tests/test_datapipes_rioxarray.py
+++ b/zen3geo/tests/test_datapipes_rioxarray.py
@@ -1,5 +1,5 @@
 """
-Tests for datapipes.
+Tests for rioxarray datapipes.
 """
 from torchdata.datapipes.iter import IterableWrapper
 


### PR DESCRIPTION
Reorganizing some files in anticipation of new features coming soon!

This is how it looks like now at https://zen3geo--18.org.readthedocs.build/en/18/api.html#module-zen3geo.datapipes.rioxarray

![image](https://user-images.githubusercontent.com/23487320/172748800-992ae19e-a9aa-4e9d-956f-76a2aec5398f.png)
