### PR TITLE
:children_crossing: Walkthrough on creating batches of data chips

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -7,8 +7,8 @@ chapters:
   - title: 🦮 Walkthrough
     file: walkthrough
     sections:
-      - title: 🀄 Batching
-        file: batching
+      - title: 🀄 Chipping and Batching
+        file: chipping
   - title: 📖 API Reference
     file: api
   - title: 📆 Changelog

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -6,6 +6,9 @@ root: index
 chapters:
   - title: 🦮 Walkthrough
     file: walkthrough
+    sections:
+      - title: 🀄 Batching
+        file: batching
   - title: 📖 API Reference
     file: api
   - title: 📆 Changelog

--- a/docs/batching.md
+++ b/docs/batching.md
@@ -1,0 +1,84 @@
+---
+jupytext:
+  formats: md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+---
+
+# Batching data
+
+Following on from the previous tutorial,
+let's learn more about creating a more complicated raster data pipeline.
+Specifically, we'll go through the following:
+- Loading Cloud-Optimized GeoTIFFs (COGs) from different geographic projections
+- Cut up each large GeoTIFF into several non-overlapping chips
+- Create batches of chips/tensors to feed into a DataLoader
+
+Some terminology disambiguation:
+- scene - the big image (e.g. 10000x10000 pixels) from a satellite (e.g. a GeoTIFF)
+- chip - the small image (e.g. 512x512 pixels) cut out from a satellite scene to be loaded as a tensor
+
+See also:
+- https://github.com/microsoft/torchgeo/wiki/Design-Decisions#chip-vs-tile-vs-region
+- https://github.com/cogeotiff/cog-spec/blob/master/spec.md
+
+## 🎉 **Getting started**
+
+Load up them libraries!
+
+```{code-cell}
+import pystac
+import planetary_computer
+import rioxarray
+
+import torchdata
+import zen3geo
+```
+
+## 0️⃣ Find [Cloud-Optimized GeoTIFFs](https://www.cogeo.org) 🗺️
+
+Synthetic-Aperture Radar (SAR) from a [STAC](https://stacspec.org) catalog!
+We'll get some Sentinel-1 Ground-Range Detected (GRD) data over Osaka and Tokyo
+in Japan 🇯🇵.
+
+🔗 Links:
+- [Official Sentinel-1 description page at ESA](https://sentinel.esa.int/web/sentinel/missions/sentinel-1)
+- [Microsoft Planetary Computer STAC Explorer](https://planetarycomputer.microsoft.com/explore?c=137.4907%2C35.0014&z=7.94&v=2&d=sentinel-1-grd&s=false%3A%3A100%3A%3Atrue&ae=0&m=cql%3A08211c0dd907a5066c41422c75629d5f&r=VV%2C+VH+False-color+composite)
+- [AWS Sentinel-1 Cloud-Optimized GeoTIFFs](https://registry.opendata.aws/sentinel-1)
+
+
+```{code-cell}
+item_urls = [
+    "https://planetarycomputer.microsoft.com/api/stac/v1/collections/sentinel-1-grd/items/S1A_IW_GRDH_1SDV_20220614T210034_20220614T210059_043664_05368A",  # Osaka
+    "https://planetarycomputer.microsoft.com/api/stac/v1/collections/sentinel-1-grd/items/S1A_IW_GRDH_1SDV_20220616T204349_20220616T204414_043693_053764",  # Tokyo
+]
+
+# Load each STAC item's metadata and sign the assets
+items = [pystac.Item.from_file(item_url) for item_url in item_urls]
+signed_items = [planetary_computer.sign(item) for item in items]
+signed_items
+```
+
+### Inspect one of the data assets 🍱
+
+The Sentinel-1 STAC item contains several assets.
+These include different 〰️ polarizations (e.g. 'VH', 'VV').
+Let's just use the 'thumbnail' product for now which is an RGB preview, with
+the red channel (R) representing the co-polarization (VV or HH), the green
+channel (G) representing the cross-polarization (VH or HV) and the blue channel
+(B) representing the ratio of the cross and co-polarizations.
+
+```{code-cell}
+url: str = signed_items[0].assets["thumbnail"].href
+da = rioxarray.open_rasterio(filename=url)
+da
+```
+
+This is how the Sentinel-1 radar image looks like over Osaka on 14 June 2022.
+
+![Sentinel-1 image over Osaka, Japan on 20220614](https://planetarycomputer.microsoft.com/api/data/v1/item/preview.png?collection=sentinel-1-grd&item=S1A_IW_GRDH_1SDV_20220614T210034_20220614T210059_043664_05368A&assets=vv&assets=vh&expression=vv%2Cvh%2Cvv%2Fvh&rescale=0%2C500&rescale=0%2C300&rescale=0%2C7&tile_format=png)

--- a/poetry.lock
+++ b/poetry.lock
@@ -2268,14 +2268,14 @@ docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco-itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
 
 [extras]
-docs = ["jupyter-book", "planetary-computer", "pystac"]
-raster = []
+docs = ["jupyter-book", "planetary-computer", "pystac", "xbatcher"]
+raster = ["xbatcher"]
 vector = ["pyogrio"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "c3518275926de7d4673644383f1708cc23ebc1caef8b08c99c2645ea016e9a83"
+content-hash = "e83584761bd793bdb092a059f42aab92f651a2303aeb74215e3213d43a36c805"
 
 [metadata.files]
 affine = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,8 @@ pytest = "*"
 docs = [
     "jupyter-book",
     "planetary-computer",
-    "pystac"
+    "pystac",
+    "xbatcher"
 ]
 raster = ["xbatcher"]
 vector = ["pyogrio"]

--- a/zen3geo/datapipes/xbatcher.py
+++ b/zen3geo/datapipes/xbatcher.py
@@ -94,7 +94,12 @@ class XbatcherSlicerIterDataPipe(IterDataPipe[Union[xr.DataArray, xr.Dataset]]):
     def __iter__(self) -> Iterator[Union[xr.DataArray, xr.Dataset]]:
         for dataarray in self.source_datapipe:
             if hasattr(dataarray, "name") and dataarray.name is None:
-                dataarray.name = "z"
+                # Workaround for ValueError: unable to convert unnamed
+                # DataArray to a Dataset without providing an explicit name
+                dataarray = dataarray.to_dataset(
+                    name=xr.backends.api.DATAARRAY_VARIABLE
+                )[xr.backends.api.DATAARRAY_VARIABLE]
+                # dataarray.name = "z"  # doesn't work for some reason
             for chip in dataarray.batch.generator(
                 input_dims=self.input_dims, **self.kwargs
             ):


### PR DESCRIPTION
Initial tutorial on creating batches of chipped data (256x256) from full-size satellite scenes (10000x10000) with different coordinate reference systems! Using example Sentinel-1 GRD GeoTIFFs over Osaka and Tokyo in Japan.

**Preview** at https://zen3geo--20.org.readthedocs.build/en/20/chipping.html

| Osaka | Tokyo |
|--|--|
| ![Sentinel-1 image over Osaka, Japan on 20220614](https://planetarycomputer.microsoft.com/api/data/v1/item/preview.png?collection=sentinel-1-grd&item=S1A_IW_GRDH_1SDV_20220614T210034_20220614T210059_043664_05368A&assets=vv&assets=vh&expression=vv%3Bvh%3Bvv%2Fvh&rescale=0%2C600&rescale=0%2C270&rescale=0%2C9&asset_as_band=True&tile_format=png&format=png) | ![Sentinel-1 image over Tokyo, Japan on 20220616](https://planetarycomputer.microsoft.com/api/data/v1/item/preview.png?collection=sentinel-1-grd&item=S1A_IW_GRDH_1SDV_20220616T204349_20220616T204414_043693_053764&assets=vv&assets=vh&expression=vv%2Cvh%2Cvv%2Fvh&rescale=0%2C500&rescale=0%2C300&rescale=0%2C7&tile_format=png) |

https://planetarycomputer.microsoft.com/explore?c=137.1529%2C35.0944&z=7.94&v=2&d=sentinel-1-grd&s=false%3A%3A100%3A%3Atrue&ae=0&m=cql%3A08211c0dd907a5066c41422c75629d5f&r=VV%2C+VH+False-color+composite

TODO:
- [x] Handle multiple UTM projections by not handling them
- [x] Integrate with xbatcher, xref #22
- [x] Batch together several chips, may need to wait for https://github.com/pangeo-data/xbatcher/issues/70
