### PR TITLE
:sparkles: XbatcherSlicerIterDataPipe for slicing xarray.DataArray

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -33,7 +33,7 @@ jobs:
         include:
           - os: 'ubuntu-22.04'
             python-version: '3.9'
-            extra-packages: '--extras vector'
+            extra-packages: '--extras "raster vector"'
 
     steps:
       # Checkout current git repository

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -114,7 +114,7 @@ mamba create --name zen3geo python=3.9
 mamba activate
 
 pip install poetry==1.2.0b2
-poetry install
+poetry install --extras "raster vector"
 ```
 
 ### Building documentation 📖

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -111,7 +111,7 @@ cd zen3geo
 
 ```
 mamba create --name zen3geo python=3.9
-mamba activate
+mamba activate zen3geo
 
 pip install poetry==1.2.0b2
 poetry install --extras "raster vector"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -56,6 +56,9 @@ sphinx:
       xarray:
         - 'https://xarray.pydata.org/en/latest/'
         - null
+      xbatcher:
+        - 'https://xbatcher.readthedocs.io/en/latest/'
+        - null
   extra_extensions:
     - 'sphinx.ext.autodoc'
     - 'sphinx.ext.intersphinx'

--- a/docs/api.md
+++ b/docs/api.md
@@ -24,3 +24,12 @@
 .. autoclass:: zen3geo.datapipes.pyogrio.PyogrioReaderIterDataPipe
     :show-inheritance:
 ```
+
+### Xbatcher
+
+```{eval-rst}
+.. automodule:: zen3geo.datapipes.xbatcher
+.. autoclass:: zen3geo.datapipes.XbatcherSlicer
+.. autoclass:: zen3geo.datapipes.xbatcher.XbatcherSlicerIterDataPipe
+    :show-inheritance:
+```

--- a/poetry.lock
+++ b/poetry.lock
@@ -250,12 +250,44 @@ click = ">=4.0"
 test = ["pytest-cov"]
 
 [[package]]
+name = "cloudpickle"
+version = "2.1.0"
+description = "Extended pickling support for Python objects"
+category = "main"
+optional = true
+python-versions = ">=3.6"
+
+[[package]]
 name = "colorama"
 version = "0.4.4"
 description = "Cross-platform colored terminal text."
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "dask"
+version = "2022.6.1"
+description = "Parallel PyData with Task Scheduling"
+category = "main"
+optional = true
+python-versions = ">=3.8"
+
+[package.dependencies]
+cloudpickle = ">=1.1.1"
+fsspec = ">=0.6.0"
+packaging = ">=20.0"
+partd = ">=0.3.10"
+pyyaml = ">=5.3.1"
+toolz = ">=0.8.2"
+
+[package.extras]
+array = ["numpy (>=1.18)"]
+complete = ["bokeh (>=2.4.2)", "distributed (==2022.6.1)", "jinja2", "numpy (>=1.18)", "pandas (>=1.0)"]
+dataframe = ["numpy (>=1.18)", "pandas (>=1.0)"]
+diagnostics = ["bokeh (>=2.4.2)", "jinja2"]
+distributed = ["distributed (==2022.6.1)"]
+test = ["pytest", "pytest-rerunfailures", "pytest-xdist", "pre-commit"]
 
 [[package]]
 name = "debugpy"
@@ -339,6 +371,37 @@ all = ["boto3 (>=1.2.4)", "pytest-cov", "shapely", "pytest (>=3)", "mock"]
 calc = ["shapely"]
 s3 = ["boto3 (>=1.2.4)"]
 test = ["pytest (>=3)", "pytest-cov", "boto3 (>=1.2.4)", "mock"]
+
+[[package]]
+name = "fsspec"
+version = "2022.5.0"
+description = "File-system specification"
+category = "main"
+optional = true
+python-versions = ">=3.7"
+
+[package.extras]
+abfs = ["adlfs"]
+adl = ["adlfs"]
+arrow = ["pyarrow (>=1)"]
+dask = ["dask", "distributed"]
+dropbox = ["dropboxdrivefs", "requests", "dropbox"]
+entrypoints = ["importlib-metadata"]
+fuse = ["fusepy"]
+gcs = ["gcsfs"]
+git = ["pygit2"]
+github = ["requests"]
+gs = ["gcsfs"]
+gui = ["panel"]
+hdfs = ["pyarrow (>=1)"]
+http = ["requests", "aiohttp"]
+libarchive = ["libarchive-c"]
+oci = ["ocifs"]
+s3 = ["s3fs"]
+sftp = ["paramiko"]
+smb = ["smbprotocol"]
+ssh = ["paramiko"]
+tqdm = ["tqdm"]
 
 [[package]]
 name = "geopandas"
@@ -771,6 +834,14 @@ doc = ["sphinx", "sphinx-book-theme", "myst-parser"]
 test = ["coverage", "pytest", "pytest-cov"]
 
 [[package]]
+name = "locket"
+version = "1.0.0"
+description = "File-based locks for Python on Linux and Windows"
+category = "main"
+optional = true
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
 name = "markdown-it-py"
 version = "1.1.0"
 description = "Python port of markdown-it. Markdown parsing, done right!"
@@ -1092,6 +1163,21 @@ python-versions = ">=3.6"
 [package.extras]
 qa = ["flake8 (==3.8.3)", "mypy (==0.782)"]
 testing = ["docopt", "pytest (<6.0.0)"]
+
+[[package]]
+name = "partd"
+version = "1.2.0"
+description = "Appendable key-value storage"
+category = "main"
+optional = true
+python-versions = ">=3.5"
+
+[package.dependencies]
+locket = "*"
+toolz = "*"
+
+[package.extras]
+complete = ["numpy (>=1.9.0)", "pandas (>=0.19.0)", "pyzmq", "blosc"]
 
 [[package]]
 name = "pathspec"
@@ -2002,6 +2088,14 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
+name = "toolz"
+version = "0.11.2"
+description = "List processing tools and functional utilities"
+category = "main"
+optional = true
+python-versions = ">=3.5"
+
+[[package]]
 name = "torch"
 version = "1.11.0"
 description = "Tensors and Dynamic neural networks in Python with strong GPU acceleration"
@@ -2149,6 +2243,26 @@ parallel = ["dask"]
 viz = ["matplotlib", "seaborn", "nc-time-axis"]
 
 [[package]]
+name = "xbatcher"
+version = "0.1.0.post67"
+description = "Batch generation from xarray dataset"
+category = "main"
+optional = true
+python-versions = ">=3.7"
+develop = false
+
+[package.dependencies]
+dask = "*"
+numpy = "*"
+xarray = "*"
+
+[package.source]
+type = "git"
+url = "https://github.com/pangeo-data/xbatcher.git"
+reference = "HEAD"
+resolved_reference = "d3e1c2f75dd0eea4e699b3398ba4d8bc1035a5e5"
+
+[[package]]
 name = "zipp"
 version = "3.8.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
@@ -2167,7 +2281,7 @@ vector = ["pyogrio"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "489a37991d7e227379c9f398018b42ac977d161ab1de07180954b11b9e06cb29"
+content-hash = "539396ebced00dc77ea622826b2553e698815e10ca3712503394f382aeea90b8"
 
 [metadata.files]
 affine = [
@@ -2338,9 +2452,17 @@ cligj = [
     {file = "cligj-0.7.2-py3-none-any.whl", hash = "sha256:c1ca117dbce1fe20a5809dc96f01e1c2840f6dcc939b3ddbb1111bf330ba82df"},
     {file = "cligj-0.7.2.tar.gz", hash = "sha256:a4bc13d623356b373c2c27c53dbd9c68cae5d526270bfa71f6c6fa69669c6b27"},
 ]
+cloudpickle = [
+    {file = "cloudpickle-2.1.0-py3-none-any.whl", hash = "sha256:b5c434f75c34624eedad3a14f2be5ac3b5384774d5b0e3caf905c21479e6c4b1"},
+    {file = "cloudpickle-2.1.0.tar.gz", hash = "sha256:bb233e876a58491d9590a676f93c7a5473a08f747d5ab9df7f9ce564b3e7938e"},
+]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
+]
+dask = [
+    {file = "dask-2022.6.1-py3-none-any.whl", hash = "sha256:fbd2707070ee8cba080a297301c3984de3d0dee211f30c81387d5fa8adc7de74"},
+    {file = "dask-2022.6.1.tar.gz", hash = "sha256:6ecc4571da3e5575dd1fa1537237434908f81b929f7f2a3493a7f6eb8507903e"},
 ]
 debugpy = [
     {file = "debugpy-1.6.0-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:eb1946efac0c0c3d411cea0b5ac772fbde744109fd9520fb0c5a51979faf05ad"},
@@ -2398,6 +2520,10 @@ fiona = [
     {file = "Fiona-1.8.21-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:388acc9fa07ba7858d508dfe826d4b04d813818bced16c4049de19cc7ca322ef"},
     {file = "Fiona-1.8.21-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:40b4eaf5b88407421d6c9e707520abd2ff16d7cd43efb59cd398aa41d2de332c"},
     {file = "Fiona-1.8.21.tar.gz", hash = "sha256:3a0edca2a7a070db405d71187214a43d2333a57b4097544a3fcc282066a58bfc"},
+]
+fsspec = [
+    {file = "fsspec-2022.5.0-py3-none-any.whl", hash = "sha256:2c198c50eb541a80bbd03540b07602c4a957366f3fb416a1f270d34bd4ff0926"},
+    {file = "fsspec-2022.5.0.tar.gz", hash = "sha256:7a5459c75c44e760fbe6a3ccb1f37e81e023cde7da8ba20401258d877ec483b4"},
 ]
 geopandas = [
     {file = "geopandas-0.11.0-py3-none-any.whl", hash = "sha256:0991f279d4f9e3a04e3666f32b1ac64d6ba439933da3d9654a26031e0ccea5dc"},
@@ -2560,6 +2686,10 @@ linkify-it-py = [
     {file = "linkify-it-py-1.0.3.tar.gz", hash = "sha256:2b3f168d5ce75e3a425e34b341a6b73e116b5d9ed8dbbbf5dc7456843b7ce2ee"},
     {file = "linkify_it_py-1.0.3-py3-none-any.whl", hash = "sha256:11e29f00150cddaa8f434153f103c14716e7e097a8fd372d9eb1ed06ed91524d"},
 ]
+locket = [
+    {file = "locket-1.0.0-py2.py3-none-any.whl", hash = "sha256:b6c819a722f7b6bd955b80781788e4a66a55628b858d347536b7e81325a3a5e3"},
+    {file = "locket-1.0.0.tar.gz", hash = "sha256:5c0d4c052a8bbbf750e056a8e65ccd309086f4f0f18a2eac306a8dfa4112a632"},
+]
 markdown-it-py = [
     {file = "markdown-it-py-1.1.0.tar.gz", hash = "sha256:36be6bb3ad987bfdb839f5ba78ddf094552ca38ccbd784ae4f74a4e1419fc6e3"},
     {file = "markdown_it_py-1.1.0-py3-none-any.whl", hash = "sha256:98080fc0bc34c4f2bcf0846a096a9429acbd9d5d8e67ed34026c03c61c464389"},
@@ -2716,6 +2846,10 @@ pandocfilters = [
 parso = [
     {file = "parso-0.8.3-py2.py3-none-any.whl", hash = "sha256:c001d4636cd3aecdaf33cbb40aebb59b094be2a74c556778ef5576c175e19e75"},
     {file = "parso-0.8.3.tar.gz", hash = "sha256:8c07be290bb59f03588915921e29e8a50002acaf2cdc5fa0e0114f91709fafa0"},
+]
+partd = [
+    {file = "partd-1.2.0-py3-none-any.whl", hash = "sha256:5c3a5d70da89485c27916328dc1e26232d0e270771bd4caef4a5124b6a457288"},
+    {file = "partd-1.2.0.tar.gz", hash = "sha256:aa67897b84d522dcbc86a98b942afab8c6aa2f7f677d904a616b74ef5ddbc3eb"},
 ]
 pathspec = [
     {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
@@ -3300,6 +3434,10 @@ tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
+toolz = [
+    {file = "toolz-0.11.2-py3-none-any.whl", hash = "sha256:a5700ce83414c64514d82d60bcda8aabfde092d1c1a8663f9200c07fdcc6da8f"},
+    {file = "toolz-0.11.2.tar.gz", hash = "sha256:6b312d5e15138552f1bda8a4e66c30e236c831b612b2bf0005f8a1df10a4bc33"},
+]
 torch = [
     {file = "torch-1.11.0-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:62052b50fffc29ca7afc0c04ef8206b6f1ca9d10629cb543077e12967e8d0398"},
     {file = "torch-1.11.0-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:866bfba29ac98dec35d893d8e17eaec149d0ac7a53be7baae5c98069897db667"},
@@ -3407,6 +3545,7 @@ xarray = [
     {file = "xarray-2022.3.0-py3-none-any.whl", hash = "sha256:560f36eaabe7a989d5583d37ec753dd737357aa6a6453e55c80bb4f92291a69e"},
     {file = "xarray-2022.3.0.tar.gz", hash = "sha256:398344bf7d170477aaceff70210e11ebd69af6b156fe13978054d25c48729440"},
 ]
+xbatcher = []
 zipp = [
     {file = "zipp-3.8.0-py3-none-any.whl", hash = "sha256:c4f6e5bbf48e74f7a38e7cc5b0480ff42b0ae5178957d564d18932525d5cf099"},
     {file = "zipp-3.8.0.tar.gz", hash = "sha256:56bf8aadb83c24db6c4b577e13de374ccfb67da2078beba1d037c17980bf43ad"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -2276,12 +2276,13 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 
 [extras]
 docs = ["jupyter-book", "planetary-computer", "pystac"]
+raster = ["xbatcher"]
 vector = ["pyogrio"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "539396ebced00dc77ea622826b2553e698815e10ca3712503394f382aeea90b8"
+content-hash = "8092ee6f6a1c7b10476ce96ff65b66eacfd5864669a16d4fe12ca50fd6eb2626"
 
 [metadata.files]
 affine = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,9 @@ classifiers = [
 python = "^3.8"
 rioxarray = ">=0.10.0"
 torchdata = ">=0.3.0"
+# Optional
 pyogrio = {version = ">=0.4.0", extras = ["geopandas"], optional = true}
+xbatcher = {git = "https://github.com/pangeo-data/xbatcher.git", optional = true}
 # Docs
 jupyter-book = {version="*", optional=true}
 planetary-computer = {version="*", optional=true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ docs = [
     "planetary-computer",
     "pystac"
 ]
+raster = ["xbatcher"]
 vector = ["pyogrio"]
 
 [tool.poetry-dynamic-versioning]

--- a/zen3geo/datapipes/__init__.py
+++ b/zen3geo/datapipes/__init__.py
@@ -4,3 +4,4 @@ Iterable-style DataPipes for geospatial raster 🌈 and vector 🚏 data.
 
 from zen3geo.datapipes.pyogrio import PyogrioReaderIterDataPipe as PyogrioReader
 from zen3geo.datapipes.rioxarray import RioXarrayReaderIterDataPipe as RioXarrayReader
+from zen3geo.datapipes.xbatcher import XbatcherSlicerIterDataPipe as XbatcherSlicer

--- a/zen3geo/datapipes/xbatcher.py
+++ b/zen3geo/datapipes/xbatcher.py
@@ -1,0 +1,104 @@
+"""
+DataPipes for :doc:`xbatcher <xbatcher:index>`.
+"""
+from typing import Any, Dict, Hashable, Iterator, Optional, Tuple, Union
+
+import xarray as xr
+
+try:
+    import xbatcher
+except ImportError:
+    xbatcher = None
+from torchdata.datapipes import functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe
+
+
+@functional_datapipe("slice_with_xbatcher")
+class XbatcherSlicerIterDataPipe(IterDataPipe[Union[xr.DataArray, xr.Dataset]]):
+    """
+    Takes an :py:class:`xarray.DataArray` or :py:class:`xarray.Dataset`
+    and creates a sliced window view (also known as a chip or tile) of the
+    n-dimensional array (functional name: ``slice_with_xbatcher``).
+
+    Parameters
+    ----------
+    source_datapipe : IterDataPipe[xr.DataArray]
+        A DataPipe that contains :py:class:`xarray.DataArray` or
+        :py:class:`xarray.Dataset` objects.
+
+    input_dims : dict
+        A dictionary specifying the size of the inputs in each dimension to
+        slice along, e.g. ``{'lon': 64, 'lat': 64}``. These are the dimensions
+        the machine learning library will see. All other dimensions will be
+        stacked into one dimension called ``batch``.
+
+    kwargs : Optional
+        Extra keyword arguments to pass to :py:func:`xbatcher.BatchGenerator`.
+
+    Yields
+    ------
+    chip : xarray.DataArray
+        An :py:class:`xarray.DataArray` or :py:class:`xarray.Dataset` object
+        containing the sliced raster data, with the size/shape defined by the
+        ``input_dims`` parameter.
+
+    Raises
+    ------
+    ModuleNotFoundError
+        If ``xbatcher`` is not installed. Follow
+        :doc:`install instructions for xbatcher <xbatcher:index>`
+        before using this class.
+
+    Example
+    -------
+    >>> import pytest
+    >>> import numpy as np
+    >>> import xarray as xr
+    >>> xbatcher = pytest.importorskip("xbatcher")
+    ...
+    >>> from torchdata.datapipes.iter import IterableWrapper
+    >>> from zen3geo.datapipes import XbatcherSlicer
+    ...
+    >>> # Sliced window view of xarray.DataArray using DataPipe
+    >>> dataarray: xr.DataArray = xr.DataArray(
+    ...     data=np.ones(shape=(3, 128, 128)),
+    ...     name="foo",
+    ...     dims=["band", "y", "x"]
+    ... )
+    >>> dp = IterableWrapper(iterable=[dataarray])
+    >>> dp_xbatcher = dp.slice_with_xbatcher(input_dims={"y": 64, "x": 64})
+    ...
+    >>> # Loop or iterate over the DataPipe stream
+    >>> it = iter(dp_xbatcher)
+    >>> dataarray_chip = next(it)
+    >>> dataarray_chip
+    <xarray.Dataset>
+    Dimensions:  (band: 3, y: 64, x: 64)
+    Dimensions without coordinates: band, y, x
+    Data variables:
+        foo      (band, y, x) float64 1.0 1.0 1.0 1.0 1.0 ... 1.0 1.0 1.0 1.0 1.0
+    """
+
+    def __init__(
+        self,
+        source_datapipe: IterDataPipe[Union[xr.DataArray, xr.Dataset]],
+        input_dims: Dict[Hashable, int],
+        **kwargs: Optional[Dict[str, Any]]
+    ) -> None:
+        self.source_datapipe: IterDataPipe[
+            Union[xr.DataArray, xr.Dataset]
+        ] = source_datapipe
+        self.input_dims: Dict[Hashable, int] = input_dims
+        self.kwargs = kwargs
+
+    def __iter__(self) -> Iterator[Union[xr.DataArray, xr.Dataset]]:
+        for dataarray in self.source_datapipe:
+            if dataarray.name is None:
+                dataarray.name = "z"
+            for chip in dataarray.batch.generator(
+                input_dims=self.input_dims, **self.kwargs
+            ):
+                yield chip
+
+        # def __len__(self) -> int:
+        #     return len(self.source_datapipe)

--- a/zen3geo/datapipes/xbatcher.py
+++ b/zen3geo/datapipes/xbatcher.py
@@ -93,7 +93,7 @@ class XbatcherSlicerIterDataPipe(IterDataPipe[Union[xr.DataArray, xr.Dataset]]):
 
     def __iter__(self) -> Iterator[Union[xr.DataArray, xr.Dataset]]:
         for dataarray in self.source_datapipe:
-            if dataarray.name is None:
+            if hasattr(dataarray, "name") and dataarray.name is None:
                 dataarray.name = "z"
             for chip in dataarray.batch.generator(
                 input_dims=self.input_dims, **self.kwargs

--- a/zen3geo/tests/test_datapipes_xbatcher.py
+++ b/zen3geo/tests/test_datapipes_xbatcher.py
@@ -33,3 +33,30 @@ def test_xbatcher_slicer_dataarray():
 
     assert dataarray_chip.sizes == {"band": 3, "y": 64, "x": 64}
     assert dataarray_chip.sum() == 3 * 64 * 64
+
+
+def test_xbatcher_slicer_dataset():
+    """
+    Ensure that XbatcherSlicer works to slice an xarray.Dataset object and
+    outputs a smaller xarray.Dataset chip.
+    """
+
+    dataset: xr.Dataset = xr.Dataset(
+        data_vars={"temperature": (["x", "y"], 15 * np.ones(shape=(32, 32)))},
+        coords={
+            "lon": (["x"], np.linspace(start=0, stop=32, num=32)),
+            "lat": (["y"], np.linspace(start=64, stop=32, num=32)),
+        },
+    )
+    dp = IterableWrapper(iterable=[dataset])
+
+    # Using class constructors
+    dp_xbatcher = XbatcherSlicer(source_datapipe=dp, input_dims={"y": 16, "x": 16})
+    # Using functional form (recommended)
+    dp_xbatcher = dp.slice_with_xbatcher(input_dims={"y": 16, "x": 16})
+
+    it = iter(dp_xbatcher)
+    dataset_chip = next(it)
+
+    assert dataset_chip.temperature.sizes == {"y": 16, "x": 16}
+    assert dataset_chip.temperature.sum() == 15 * 16 * 16

--- a/zen3geo/tests/test_datapipes_xbatcher.py
+++ b/zen3geo/tests/test_datapipes_xbatcher.py
@@ -2,10 +2,13 @@
 Tests for xbatcher datapipes.
 """
 import numpy as np
+import pytest
 import xarray as xr
 from torchdata.datapipes.iter import IterableWrapper
 
 from zen3geo.datapipes import XbatcherSlicer
+
+xbatcher = pytest.importorskip("xbatcher")
 
 
 # %%

--- a/zen3geo/tests/test_datapipes_xbatcher.py
+++ b/zen3geo/tests/test_datapipes_xbatcher.py
@@ -1,0 +1,32 @@
+"""
+Tests for xbatcher datapipes.
+"""
+import numpy as np
+import xarray as xr
+from torchdata.datapipes.iter import IterableWrapper
+
+from zen3geo.datapipes import XbatcherSlicer
+
+
+# %%
+def test_xbatcher_slicer_dataarray():
+    """
+    Ensure that XbatcherSlicer works to slice an xarray.DataArray object and
+    outputs a smaller xarray.DataArray chip.
+    """
+
+    dataarray: xr.DataArray = xr.DataArray(
+        data=np.ones(shape=(3, 128, 128)), dims=["band", "y", "x"]
+    ).chunk({"band": 1})
+    dp = IterableWrapper(iterable=[dataarray])
+
+    # Using class constructors
+    dp_xbatcher = XbatcherSlicer(source_datapipe=dp, input_dims={"y": 64, "x": 64})
+    # Using functional form (recommended)
+    dp_xbatcher = dp.slice_with_xbatcher(input_dims={"y": 64, "x": 64})
+
+    it = iter(dp_xbatcher)
+    dataarray_chip = next(it)
+
+    assert dataarray_chip.sizes == {"band": 3, "y": 64, "x": 64}
+    assert dataarray_chip.sum() == 3 * 64 * 64


### PR DESCRIPTION
An iterable-style [DataPipe](https://github.com/pytorch/data/tree/v0.4.0#what-are-datapipes) for creating chips from `xarray.DataArray` objects! The windowed slicing is done using [xbatcher](https://xbatcher.readthedocs.io/en/latest).

Note that `xbatcher` is only used here to create slices of data (or chips/tiles), the actual creation of mini-batches (lumping together several slices/chips/tiles of images) will be handled by https://pytorch.org/data/0.4.0/generated/torchdata.datapipes.iter.Batcher.html

**Preview** at https://zen3geo--22.org.readthedocs.build/en/19/api.html#module-zen3geo.datapipes.xbatcher

Note that since `xbatcher` is made an optional dependency, users would need to do `pip install zen3geo[raster]` to install the extra 'raster' packages that includes `xbatcher` (and possibly more in the future).

TODO:
- [x] Add `xbatcher` as optional dependency
- [x] Initial implementation of `XbatcherSlicerIterDataPipe`
- [x] Update CI build matrix to include optional `xbatcher` dependency in full tests run
- [x] Add unit test for slicing `xarray.Dataset` objects
- [ ] Think about refactoring RioXarrayReader and PyogrioReader to not return tuples of (filename, dataobj) (maybe do in separate PR).