### PR TITLE
:recycle: Let RioXarrayReader return dataarray only instead of tuple

### DIFF
--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -165,14 +165,14 @@ At the most basic level, you could iterate through the DataPipe like so:
 
 ```{code-cell}
 it = iter(dp_rioxarray_zoom3)
-filename, dataarray = next(it)
+dataarray = next(it)
 dataarray
 ```
 
 Or if you're more familiar with a for-loop, here it is:
 
 ```{code-cell}
-for filename, dataarray in dp_rioxarray_zoom3:
+for dataarray in dp_rioxarray_zoom3:
     print(dataarray)
     # Run model on this data batch
 ```
@@ -189,11 +189,10 @@ def fn(da):
 ```
 
 Using {py:class}`torchdata.datapipes.iter.Mapper`,
-we'll apply the tensor conversion function to index 1 of the
-``(filename, dataarray)`` tuple.
+we'll apply the tensor conversion function to each dataarray in the DataPipe.
 
 ```{code-cell}
-dp_tensor = dp_rioxarray_zoom3.map(fn=fn, input_col=1)
+dp_tensor = dp_rioxarray_zoom3.map(fn=fn)
 dp_tensor
 ```
 
@@ -202,7 +201,7 @@ Finally, let's put our DataPipe into a {py:class}`torch.utils.data.DataLoader`!
 ```{code-cell}
 dataloader = torch.utils.data.DataLoader(dataset=dp_tensor)
 for batch in dataloader:
-    filename, tensor = batch
+    tensor = batch
     print(tensor)
 ```
 

--- a/zen3geo/tests/test_datapipes_rioxarray.py
+++ b/zen3geo/tests/test_datapipes_rioxarray.py
@@ -9,8 +9,8 @@ from zen3geo.datapipes import RioXarrayReader
 # %%
 def test_rioxarray_reader():
     """
-    Ensure that RioXarrayReader works to read in a GeoTIFF file and outputs a
-    tuple made up of a filename and an xarray.DataArray object.
+    Ensure that RioXarrayReader works to read in a GeoTIFF file and outputs an
+    xarray.DataArray object.
     """
     file_url: str = "https://github.com/GenericMappingTools/gmtserver-admin/raw/master/cache/earth_day_HD.tif"
     dp = IterableWrapper(iterable=[file_url])
@@ -22,8 +22,7 @@ def test_rioxarray_reader():
 
     assert len(dp_rioxarray) == 1
     it = iter(dp_rioxarray)
-    filename, dataarray = next(it)
+    dataarray = next(it)
 
-    assert isinstance(filename, str)
     assert dataarray.shape == (1, 960, 1920)
     assert dataarray.dims == ("band", "y", "x")


### PR DESCRIPTION
Simplify downstream slicing tasks on an `xarray.DataArray` by returning a single dataarray per iteration instead of a tuple of (filepath, dataarray).

Relates to #20 and handles bullet point in https://github.com/weiji14/zen3geo/pull/22#issue-1293631106