### PR TITLE
:sparkles: RasterioRasterizer for burning vector shapes to xarray grids

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -35,6 +35,9 @@ sphinx:
       geopandas:
         - 'https://geopandas.org/en/latest/'
         - null
+      numpy:
+        - 'https://numpy.org/doc/stable/'
+        - null
       pyogrio:
         - 'https://pyogrio.readthedocs.io/en/latest/'
         - null
@@ -46,6 +49,9 @@ sphinx:
         - null
       rioxarray:
         - 'https://corteva.github.io/rioxarray/stable/'
+        - null
+      shapely:
+        - 'https://shapely.readthedocs.io/en/latest/'
         - null
       torch:
         - 'https://pytorch.org/docs/stable/'

--- a/docs/api.md
+++ b/docs/api.md
@@ -7,6 +7,15 @@
     :members:
 ```
 
+### Rasterio
+
+```{eval-rst}
+.. automodule:: zen3geo.datapipes.rasterio
+.. autoclass:: zen3geo.datapipes.RasterioRasterizer
+.. autoclass:: zen3geo.datapipes.rasterio.RasterioRasterizerIterDataPipe
+    :show-inheritance:
+```
+
 ### Rioxarray
 
 ```{eval-rst}

--- a/zen3geo/datapipes/__init__.py
+++ b/zen3geo/datapipes/__init__.py
@@ -3,5 +3,8 @@ Iterable-style DataPipes for geospatial raster 🌈 and vector 🚏 data.
 """
 
 from zen3geo.datapipes.pyogrio import PyogrioReaderIterDataPipe as PyogrioReader
+from zen3geo.datapipes.rasterio import (
+    RasterioRasterizerIterDataPipe as RasterioRasterizer,
+)
 from zen3geo.datapipes.rioxarray import RioXarrayReaderIterDataPipe as RioXarrayReader
 from zen3geo.datapipes.xbatcher import XbatcherSlicerIterDataPipe as XbatcherSlicer

--- a/zen3geo/datapipes/rasterio.py
+++ b/zen3geo/datapipes/rasterio.py
@@ -1,0 +1,76 @@
+"""
+DataPipes for :doc:`rasterio <rasterio:index>`.
+"""
+from typing import Any, Dict, Iterator, Optional, Union
+
+import numpy as np
+import rasterio
+from torchdata.datapipes import functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe
+from torchdata.datapipes.utils import StreamWrapper
+
+
+@functional_datapipe("rasterize_with_rasterio")
+class RasterioRasterizerIterDataPipe(IterDataPipe):
+    """
+    Takes a vector :py:class:`shapely.geometry.GeometryCollection`,
+    :py:class:`geopandas.GeoSeries` or :py:class:`geopandas.GeoDataFrame` and
+    yields a raster :py:class:`numpy.ndarray` or :py:class:`xarray.DataArray`
+    image with input geometries burned in
+    (functional name: ``rasterize_with_rasterio``).
+
+    Parameters
+    ----------
+    source_datapipe : IterDataPipe[geopandas.GeoDataFrame]
+        A DataPipe that contains geometries or (`geometry`, `value`) pairs. The
+        `geometry` can either be an object that implements the geo interface
+        (e.g. :py:class:`shapely.geometry.GeometryCollection`, :py:class:`geopandas.GeoSeries` or
+        :py:class:`geopandas.GeoDataFrame`) or a GeoJSON-like object. If no
+        `value` is provided the `default_value` will be used. If `value` is
+        `None` the `fill` value will be used.
+
+    kwargs : Optional
+        Extra keyword arguments to pass to
+        :py:func:`rasterio.features.rasterize`.
+
+    Yields
+    ------
+    image : numpy.ndarray or xarray.DataArray
+        An :py:class:`numpy.ndarray` or :py:class:`xarray.DataArray` object
+        containing the raster data.
+
+    Example
+    -------
+    >>> import shapely.geometry
+    >>>
+    >>> from torchdata.datapipes.iter import IterableWrapper
+    >>> from zen3geo.datapipes import RasterioRasterizer
+    ...
+    >>> # Create a vector point geometry
+    >>> geometry = shapely.geometry.MultiPoint(points=[[0, 0], [1, 2], [3, 3]])
+    >>> dp = IterableWrapper(iterable=[geometry])
+    >>> dp_rasterio = dp.rasterize_with_rasterio(out_shape=(5, 4))
+    ...
+    >>> # Loop or iterate over the DataPipe stream
+    >>> it = iter(dp_rasterio)
+    >>> array = next(it)
+    >>> array
+    array([[1, 0, 0, 0],
+           [0, 0, 0, 0],
+           [0, 1, 0, 0],
+           [0, 0, 0, 1],
+           [0, 0, 0, 0]], dtype=uint8)
+    """
+
+    def __init__(
+        self, source_datapipe: IterDataPipe, **kwargs: Optional[Dict[str, Any]]
+    ) -> None:
+        self.source_datapipe: IterDataPipe = source_datapipe
+        self.kwargs = kwargs
+
+    def __iter__(self) -> Iterator[Union[np.ndarray]]:
+        for geodataframe in self.source_datapipe:
+            yield rasterio.features.rasterize(shapes=geodataframe, **self.kwargs)
+
+    def __len__(self) -> int:
+        return len(self.source_datapipe)

--- a/zen3geo/datapipes/rasterio.py
+++ b/zen3geo/datapipes/rasterio.py
@@ -1,33 +1,56 @@
 """
 DataPipes for :doc:`rasterio <rasterio:index>`.
 """
-from typing import Any, Dict, Iterator, Optional, Union
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
+import affine
 import numpy as np
 import rasterio
+import xarray as xr
 from torchdata.datapipes import functional_datapipe
-from torchdata.datapipes.iter import IterDataPipe
-from torchdata.datapipes.utils import StreamWrapper
+from torchdata.datapipes.iter import IterableWrapper, IterDataPipe
 
 
 @functional_datapipe("rasterize_with_rasterio")
 class RasterioRasterizerIterDataPipe(IterDataPipe):
     """
-    Takes a vector :py:class:`shapely.geometry.GeometryCollection`,
-    :py:class:`geopandas.GeoSeries` or :py:class:`geopandas.GeoDataFrame` and
-    yields a raster :py:class:`numpy.ndarray` or :py:class:`xarray.DataArray`
-    image with input geometries burned in
-    (functional name: ``rasterize_with_rasterio``).
+    Takes a vector :py:class:`geopandas.GeoSeries`,
+    :py:class:`geopandas.GeoDataFrame` or
+    :py:class:`shapely.geometry.GeometryCollection`, and yields a raster
+    :py:class:`xarray.DataArray` or :py:class:`numpy.ndarray` image with input
+    geometries burned in (functional name: ``rasterize_with_rasterio``).
 
     Parameters
     ----------
     source_datapipe : IterDataPipe[geopandas.GeoDataFrame]
         A DataPipe that contains geometries or (`geometry`, `value`) pairs. The
-        `geometry` can either be an object that implements the geo interface
-        (e.g. :py:class:`shapely.geometry.GeometryCollection`, :py:class:`geopandas.GeoSeries` or
-        :py:class:`geopandas.GeoDataFrame`) or a GeoJSON-like object. If no
-        `value` is provided the `default_value` will be used. If `value` is
-        `None` the `fill` value will be used.
+        `geometry` can either be:
+
+        - :py:class:`geopandas.GeoSeries` or :py:class:`geopandas.GeoDataFrame`
+          (recommended)
+        - :py:class:`shapely.geometry.GeometryCollection` or other
+          ``shapely.geometry`` object (Point, Line, Polygon)
+        - a GeoJSON-like :py:class:`dict` object
+        - an object that implements the geo interface (see
+          https://gist.github.com/sgillies/2217756#__geo_interface__)
+
+        If no `value` is provided the `default_value` will be used. If `value`
+        is `None` the `fill` value will be used.
+
+    out : IterDataPipe[xarray.DataArray]
+        Optional. An :py:class:`xarray.DataArray` (recommended) or
+        :py:class:`numpy.ndarray` with a given shape in which to store results.
+
+    out_shape : tuple[int, int] or list[int, int]
+        Required if ``out`` is not set. Shape of output numpy ndarray.
+
+    transform : affine.Affine
+        Optional. An affine.Affine object (e.g. ``from affine import Affine;
+        Affine(30.0, 0.0, 548040.0, 0.0, -30.0, "6886890.0)`` giving the affine
+        transformation used to convert raster coordinates (e.g. [0, 0]) to
+        geographic coordinates. If none is provided, the function will attempt
+        to obtain an affine transformation from the xarray object (i.e. using
+        ``out.rio.transform()``).
 
     kwargs : Optional
         Extra keyword arguments to pass to
@@ -35,9 +58,14 @@ class RasterioRasterizerIterDataPipe(IterDataPipe):
 
     Yields
     ------
-    image : numpy.ndarray or xarray.DataArray
-        An :py:class:`numpy.ndarray` or :py:class:`xarray.DataArray` object
-        containing the raster data.
+    image : xarray.DataArray or numpy.ndarray
+        An array-like object containing the raster data. The return type
+        depends on the ``out`` or ``out_shape`` parameter:
+
+        - :py:class:`xarray.DataArray` if ``out`` is an
+          :py:class:`xarray.DataArray`
+        - :py:class:`numpy.ndarray` if ``out`` is a :py:class:`numpy.ndarray`
+          or if ``out_shape`` is set.
 
     Example
     -------
@@ -63,14 +91,54 @@ class RasterioRasterizerIterDataPipe(IterDataPipe):
     """
 
     def __init__(
-        self, source_datapipe: IterDataPipe, **kwargs: Optional[Dict[str, Any]]
+        self,
+        source_datapipe: IterDataPipe,
+        out: Optional[
+            Union[IterDataPipe[xr.DataArray], IterDataPipe[np.ndarray]]
+        ] = IterableWrapper([None]),
+        out_shape: Optional[
+            Union[IterDataPipe[Tuple[int]], IterDataPipe[List[int]]]
+        ] = None,
+        transform: rasterio.Affine = rasterio.transform.IDENTITY,
+        **kwargs: Optional[Dict[str, Any]]
     ) -> None:
         self.source_datapipe: IterDataPipe = source_datapipe
+        self.out: IterDataPipe = out
+        self.out_shape: IterDataPipe = out_shape
+        self.transform: rasterio.Affine = transform
         self.kwargs = kwargs
 
-    def __iter__(self) -> Iterator[Union[np.ndarray]]:
-        for geodataframe in self.source_datapipe:
-            yield rasterio.features.rasterize(shapes=geodataframe, **self.kwargs)
+        self.len_iter_vector = len(self.source_datapipe)
+        self.len_iter_raster = len(self.out)
+
+    def __iter__(self) -> Iterator[Union[xr.DataArray, np.ndarray]]:
+        # Broadcast vector iterator to match length of raster iterator
+        fill_value = (
+            list(self.source_datapipe)[0] if self.len_iter_vector == 1 else None
+        )
+        for _out, _geoseries in self.out.zip_longest(
+            self.source_datapipe, fill_value=fill_value
+        ):
+            if hasattr(_out, "rio"):  # if raster has rioxarray accessors
+                # Get affine transform from template raster
+                _out = _out * 0  # empty xarray.DataArray template
+                if self.transform is rasterio.transform.IDENTITY:
+                    self.transform = _out.rio.transform()
+
+                # Reproject vector to same coordinate reference system as the
+                # template raster image
+                if hasattr(_geoseries, "crs") and _geoseries.crs != _out.rio.crs:
+                    _geoseries: gpd.GeoSeries = _geoseries.to_crs(
+                        crs=_out.rio.crs
+                    ).geometry
+
+            yield rasterio.features.rasterize(
+                shapes=_geoseries,
+                out=_out,
+                out_shape=self.out_shape,
+                transform=self.transform,
+                **self.kwargs
+            )
 
     def __len__(self) -> int:
-        return len(self.source_datapipe)
+        return max(self.len_iter_vector, self.len_iter_raster)

--- a/zen3geo/tests/test_datapipes_rasterio.py
+++ b/zen3geo/tests/test_datapipes_rasterio.py
@@ -3,13 +3,15 @@ Tests for rasterio datapipes.
 """
 import numpy as np
 import pytest
+import rioxarray
+import xarray as xr
 from torchdata.datapipes.iter import IterableWrapper
 
 from zen3geo.datapipes import RasterioRasterizer
 
 
 # %%
-def test_rasterio_rasterizer_geoseries():
+def test_rasterio_rasterizer_geoseries_to_ndarray():
     """
     Ensure that RasterioRasterizer works to rasterize a geopandas.GeoSeries
     object into a numpy.ndarray image.
@@ -48,3 +50,55 @@ def test_rasterio_rasterizer_geoseries():
             dtype=np.uint8,
         ),
     )
+
+
+def test_rasterio_rasterizer_geodataframe_to_dataarray():
+    """
+    Ensure that RasterioRasterizer works to rasterize a geopandas.GeoDataFrame
+    object into an xarray.DataArray image.
+    """
+    gpd = pytest.importorskip("geopandas")
+    shapely = pytest.importorskip("shapely")
+
+    # Vector data
+    geodataframe = gpd.GeoDataFrame(
+        data={
+            "geometry": [
+                shapely.geometry.box(minx=-20, miny=30, maxx=0, maxy=60),
+                shapely.geometry.box(minx=0, miny=0, maxx=20, maxy=30),
+                shapely.geometry.box(minx=20, miny=-30, maxx=40, maxy=0),
+            ]
+        },
+        crs="EPSG:4326",
+    )
+    geodataframe = geodataframe.to_crs(epsg=2193)  # New Zealand Transverse Mercator
+    dp_geodataframe = IterableWrapper(iterable=[geodataframe])
+
+    # Raster data
+    dataarray_day = rioxarray.open_rasterio(
+        filename="https://github.com/GenericMappingTools/gmtserver-admin/raw/master/cache/earth_day_HD.tif",
+    )
+    dataarray_night = rioxarray.open_rasterio(
+        filename="https://github.com/GenericMappingTools/gmtserver-admin/raw/master/cache/earth_night_HD.tif",
+    )
+    dp_dataarray = IterableWrapper(iterable=[dataarray_day, dataarray_night])
+
+    # Using class constructors
+    dp_rasterio = RasterioRasterizer(source_datapipe=dp_geodataframe, out=dp_dataarray)
+    # Using functional form (recommended)
+    dp_rasterio = dp_geodataframe.rasterize_with_rasterio(out=dp_dataarray)
+
+    # Iterate over DataPipe
+    assert len(dp_rasterio) == 2
+    it = iter(dp_rasterio)
+    _ = next(it)  # 1st iteration
+    dataarray = next(it)  # 2nd iteration
+
+    assert dataarray.shape == (1, 960, 1920)
+    assert dataarray.dims == ("band", "y", "x")
+    assert dataarray.dtype == np.uint8
+    assert dataarray.rio.crs == 4326
+    assert dataarray.rio.transform() == dataarray_night.rio.transform()
+    assert dataarray.sum() == 51200
+    assert dataarray.isin(0).sum() == 1792000
+    assert (~dataarray.isin(test_elements=[0, 1])).sum() == 0

--- a/zen3geo/tests/test_datapipes_rasterio.py
+++ b/zen3geo/tests/test_datapipes_rasterio.py
@@ -1,0 +1,50 @@
+"""
+Tests for rasterio datapipes.
+"""
+import numpy as np
+import pytest
+from torchdata.datapipes.iter import IterableWrapper
+
+from zen3geo.datapipes import RasterioRasterizer
+
+
+# %%
+def test_rasterio_rasterizer_geoseries():
+    """
+    Ensure that RasterioRasterizer works to rasterize a geopandas.GeoSeries
+    object into a numpy.ndarray image.
+    """
+    gpd = pytest.importorskip("geopandas")
+    shapely = pytest.importorskip("shapely")
+
+    geoseries = gpd.GeoSeries(
+        data=[
+            shapely.geometry.box(minx=0, miny=1, maxx=2, maxy=3),
+            shapely.geometry.box(minx=1, miny=2, maxx=3, maxy=4),
+            shapely.geometry.box(minx=2, miny=3, maxx=4, maxy=5),
+        ]
+    )
+    dp = IterableWrapper(iterable=[geoseries])
+
+    # Using class constructors
+    dp_rasterio = RasterioRasterizer(source_datapipe=dp, out_shape=(5, 4))
+    # Using functional form (recommended)
+    dp_rasterio = dp.rasterize_with_rasterio(out_shape=(5, 4))
+
+    assert len(dp_rasterio) == 1
+    it = iter(dp_rasterio)
+    ndarray = next(it)
+
+    np.testing.assert_allclose(
+        actual=ndarray,
+        desired=np.array(
+            [
+                [0, 0, 0, 0],
+                [1, 1, 0, 0],
+                [1, 1, 1, 0],
+                [0, 1, 1, 1],
+                [0, 0, 1, 1],
+            ],
+            dtype=np.uint8,
+        ),
+    )


### PR DESCRIPTION
An iterable-style [DataPipe](https://github.com/pytorch/data/tree/v0.4.0#what-are-datapipes) for turning vector geometries into raster images! Uses [`rasterio`](https://rasterio.readthedocs.io/en/latest/) to do the rasterization.

**Preview** at https://zen3geo--32.org.readthedocs.build/en/32/api.html#zen3geo.datapipes.RasterioRasterizer

Note that I had thought about using a vendored version of [`rasterio.features.rasterize`](https://rasterio.readthedocs.io/en/latest/api/rasterio.features.html#rasterio.features.rasterize) from another library. These are some bullet points:
- [geocube](https://github.com/corteva/geocube) - would fit well since it integrates with rioxarray, but it has rather heavy dependencies on `scipy`, and also uses `odc-geo` (which is ok, but more dependencies to handle).
- [regionmask](https://github.com/regionmask/regionmask/) - another promising one, with support for crossing the dateline, but the API seems a little less flexible for what needs to be done here.
- [dea_tools](https://github.com/GeoscienceAustralia/dea-notebooks). There's a `dea_tools.spatial.xr_rasterize` function which is nearly perfect at https://github.com/GeoscienceAustralia/dea-notebooks/blob/0.2.5/Frequently_used_code/Rasterize_vectorize.ipynb and https://github.com/GeoscienceAustralia/dea-notebooks/blob/0.2.5/Tools/dea_tools/spatial.py#L166-L320. But again, it has heavy dependencies like `scipy` and has several try-except/if-then clauses to handle a `.geobox` accessor. Still, it will be a useful reference for this Pull Request!

Alternatively, rasterization can also be done using [`datashader`](https://github.com/holoviz/datashader) which is super fast as it uses `numba` (see e.g. code snippet at https://github.com/weiji14/deepicedrain/blob/41917ea515edbe548975e2a25c25ff55c6eb4b1a/deepicedrain/spatiotemporal.py#L109-L133). However, on the dependencies front:
- It uses `spatialpandas` instead of `geopandas` (though see https://github.com/holoviz/datashader/issues/1006#issuecomment-859928820)
    - On `spatialpandas`'s maintainence status: there might be some major refactoring (read: unstable) according to notes in https://docs.google.com/document/d/1BkL0arf1Lz6fHgVBEJNxKbFmVN8glNQXmDKdsuT0GcU/edit# and https://gist.github.com/jpivarski/30c2671c6860393974ff3db2891f20ed
- it relies on heavy dependencies like `scipy`

That said, the turning point to switch to `datashader`-based rasterization might be when `shapely` 2.0 gets released and matures enough to the point that the geospatial `vector` Python ecosystem starts using it.

TODO:
- [x] Initial implementation of `RasterioRasterizerIterDataPipe`
- [x] Add unit test and enhancement to pass `xarray.DataArray` inputs to `out` parameter in `rasterio.features.rasterize`
- [ ] Think about refactoring PyogrioReader to not return tuples of (filename, dataobj) (maybe do in separate PR)