### PR TITLE
:sparkles: DatashaderRasterizer for burning vector shapes to xarray grids

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -50,6 +50,9 @@ sphinx:
       rioxarray:
         - 'https://corteva.github.io/rioxarray/stable/'
         - null
+      shapely:
+        - 'https://shapely.readthedocs.io/en/latest'
+        - null
       torch:
         - 'https://pytorch.org/docs/stable/'
         - null

--- a/docs/api.md
+++ b/docs/api.md
@@ -11,6 +11,8 @@
 
 ```{eval-rst}
 .. automodule:: zen3geo.datapipes.datashader
+.. autoclass:: zen3geo.datapipes.DatashaderRasterizer
+.. autoclass:: zen3geo.datapipes.datashader.DatashaderRasterizerIterDataPipe
 .. autoclass:: zen3geo.datapipes.XarrayCanvas
 .. autoclass:: zen3geo.datapipes.datashader.XarrayCanvasIterDataPipe
     :show-inheritance:

--- a/zen3geo/datapipes/__init__.py
+++ b/zen3geo/datapipes/__init__.py
@@ -2,7 +2,10 @@
 Iterable-style DataPipes for geospatial raster 🌈 and vector 🚏 data.
 """
 
-from zen3geo.datapipes.datashader import XarrayCanvasIterDataPipe as XarrayCanvas
+from zen3geo.datapipes.datashader import (
+    DatashaderRasterizerIterDataPipe as DatashaderRasterizer,
+    XarrayCanvasIterDataPipe as XarrayCanvas,
+)
 from zen3geo.datapipes.pyogrio import PyogrioReaderIterDataPipe as PyogrioReader
 from zen3geo.datapipes.rioxarray import RioXarrayReaderIterDataPipe as RioXarrayReader
 from zen3geo.datapipes.xbatcher import XbatcherSlicerIterDataPipe as XbatcherSlicer

--- a/zen3geo/datapipes/datashader.py
+++ b/zen3geo/datapipes/datashader.py
@@ -7,9 +7,164 @@ try:
     import datashader
 except ImportError:
     datashader = None
+try:
+    import spatialpandas
+except ImportError:
+    spatialpandas = None
+
 import xarray as xr
 from torchdata.datapipes import functional_datapipe
 from torchdata.datapipes.iter import IterDataPipe
+
+
+@functional_datapipe("rasterize_with_datashader")
+class DatashaderRasterizerIterDataPipe(IterDataPipe):
+    """
+    Takes vector :py:class:`geopandas.GeoSeries` or
+    :py:class:`geopandas.GeoDataFrame` geometries and rasterizes them using
+    :py:class:`datashader.Canvas` to yield an :py:class:`xarray.DataArray`
+    raster image with input geometries burned in
+    (functional name: ``rasterize_with_datashader``).
+
+    Parameters
+    ----------
+    source_datapipe : IterDataPipe[datashader.Canvas]
+        A DataPipe that contains :py:class:`datashader.Canvas` objects with a
+        ``.crs`` attribute. This will be the template defining the output
+        raster's spatial extent and x/y range.
+
+    vector_datapipe : IterDataPipe[geopandas.GeoDataFrame]
+        A DataPipe that contains :py:class:`geopandas.GeoSeries` or
+        :py:class:`geopandas.GeoDataFrame` vector geometries.
+
+    kwargs : Optional
+        Extra keyword arguments to pass to the :py:class:`datashader.Canvas`
+        class's aggregation methods such as ``datashader.Canvas.points``.
+
+    Yields
+    ------
+    raster : xarray.DataArray
+        An :py:class:`xarray.DataArray` object containing the raster data. This
+        raster will have a :py:attr:`rioxarray.rioxarray.XRasterBase.crs`
+        property and a proper affine transform viewable with
+        :py:meth:`rioxarray.rioxarray.XRasterBase.transform`.
+
+    Raises
+    ------
+    ModuleNotFoundError
+        If ``spatialpandas`` is not installed. Please install it (e.g. via
+        ``pip install spatialpandas``) before using this class.
+
+    Example
+    -------
+    >>> import pytest
+    >>> datashader = pytest.importorskip("datashader")
+    >>> pyogrio = pytest.importorskip("pyogrio")
+    >>> spatialpandas = pytest.importorskip("spatialpandas")
+    ...
+    >>> from torchdata.datapipes.iter import IterableWrapper
+    >>> from zen3geo.datapipes import DatashaderRasterizer
+    ...
+    >>> # Read in a vector point data source
+    >>> geodataframe = pyogrio.read_dataframe(
+    ...     "https://github.com/geopandas/pyogrio/raw/v0.4.0/pyogrio/tests/fixtures/test_gpkg_nulls.gpkg",
+    ...     read_geometry=True,
+    ... )
+    >>> assert geodataframe.crs == "EPSG:4326"  # longitude/latitude coords
+    >>> dp_vector = IterableWrapper(iterable=[geodataframe])
+    ...
+    >>> # Setup blank raster canvas where we will burn vector geometries onto
+    >>> canvas = datashader.Canvas(
+    ...     plot_width=5,
+    ...     plot_height=6,
+    ...     x_range=(160000.0, 620000.0),
+    ...     y_range=(0.0, 450000.0),
+    ... )
+    >>> canvas.crs = "EPSG:32631"  # UTM Zone 31N, North of Gulf of Guinea
+    >>> dp_canvas = IterableWrapper(iterable=[canvas])
+    ...
+    >>> # Rasterize vector point geometries onto blank canvas
+    >>> dp_datashader = dp_canvas.rasterize_with_datashader(
+    ...     vector_datapipe=dp_vector
+    ... )
+    ...
+    >>> # Loop or iterate over the DataPipe stream
+    >>> it = iter(dp_datashader)
+    >>> dataarray = next(it)
+    >>> dataarray
+    <xarray.DataArray (y: 6, x: 5)>
+    array([[0, 0, 0, 0, 1],
+           [0, 0, 0, 0, 0],
+           [0, 0, 0, 0, 0],
+           [0, 0, 1, 0, 0],
+           [0, 1, 0, 0, 0],
+           [1, 0, 0, 0, 0]], dtype=uint32)
+    Coordinates:
+      * x            (x) float64 2.094e+05 3.083e+05 4.072e+05 5.06e+05 6.049e+05
+      * y            (y) float64 4.157e+05 3.47e+05 2.783e+05 ... 1.41e+05 7.237e+04
+        spatial_ref  int64 0
+    ...
+    """
+
+    def __init__(
+        self,
+        source_datapipe: IterDataPipe,
+        vector_datapipe: IterDataPipe,
+        **kwargs: Optional[Dict[str, Any]],
+    ) -> None:
+        if spatialpandas is None:
+            raise ModuleNotFoundError(
+                "Package `spatialpandas` is required to be installed to use this datapipe. "
+                "Please use `pip install spatialpandas` or "
+                "`conda install -c conda-forge spatialpandas` "
+                "to install the package"
+            )
+        self.source_datapipe: IterDataPipe = source_datapipe  # datashader.Canvas
+        self.vector_datapipe: IterDataPipe = vector_datapipe  # geopandas.GeoDataFrame
+        self.kwargs = kwargs
+
+    def __iter__(self) -> Iterator[xr.DataArray]:
+        # Broadcast vector iterator to match length of raster iterator
+        fill_value: Optional = (
+            list(self.vector_datapipe).pop() if len(self.vector_datapipe) == 1 else None
+        )
+        for canvas, vector in self.source_datapipe.zip_longest(
+            self.vector_datapipe, fill_value=fill_value
+        ):
+            # Reproject vector geometries to coordinate reference system
+            # of the raster canvas if both are different
+            if vector.crs != canvas.crs:
+                vector = vector.to_crs(crs=canvas.crs)
+
+            # Convert vector to spatialpandas format to allow datashader's
+            # rasterization methods to work
+            _vector = spatialpandas.GeoDataFrame(data=vector.geometry)
+
+            # Determine geometry type to know which rasterization method to use
+            vector_dtype: spatialpandas.geometry.GeometryDtype = _vector.geometry.dtype
+            if isinstance(vector_dtype, spatialpandas.geometry.PointDtype):
+                raster: xr.DataArray = canvas.points(
+                    source=_vector, geometry="geometry", **self.kwargs
+                )
+            else:
+                raise ValueError(
+                    f"Unsupported geometry type {vector_dtype}, only "
+                    "point, line or polygon vector geometry types are supported."
+                )
+
+            # Set coordinate transform for raster and ensure affine
+            # transform is correct (the y-coordinate goes from North to South)
+            raster: xr.DataArray = raster.rio.set_crs(input_crs=canvas.crs)
+            # assert raster.rio.transform().e > 0  # y goes South to North
+            _raster: xr.DataArray = raster.rio.reproject(
+                dst_crs=canvas.crs, shape=raster.rio.shape
+            )
+            # assert _raster.rio.transform().e < 0  # y goes North to South
+
+            yield _raster
+
+    def __len__(self) -> int:
+        return len(self.source_datapipe)
 
 
 @functional_datapipe("canvas_from_xarray")
@@ -31,13 +186,16 @@ class XarrayCanvasIterDataPipe(IterDataPipe[Union[xr.DataArray, xr.Dataset]]):
         :py:meth:`rioxarray.rioxarray.XRasterBase.set_spatial_dims`.
 
     kwargs : Optional
-        Extra keyword arguments to pass to :py:func:`datashader.Canvas`.
+        Extra keyword arguments to pass to :py:class:`datashader.Canvas`.
 
     Yields
     ------
     canvas : datashader.Canvas
         A :py:class:`datashader.Canvas` object representing the same spatial
-        extent and x/y coordinates of the input raster image.
+        extent and x/y coordinates of the input raster image. This canvas
+        will also have a ``.crs`` attribute that captures the original
+        Coordinate Reference System from the input xarray object's
+        :py:attr:`rioxarray.rioxarray.XRasterBase.crs` property.
 
     Raises
     ------
@@ -85,7 +243,7 @@ class XarrayCanvasIterDataPipe(IterDataPipe[Union[xr.DataArray, xr.Dataset]]):
     def __init__(
         self,
         source_datapipe: IterDataPipe[Union[xr.DataArray, xr.Dataset]],
-        **kwargs: Optional[Dict[str, Any]]
+        **kwargs: Optional[Dict[str, Any]],
     ) -> None:
         if datashader is None:
             raise ModuleNotFoundError(
@@ -112,8 +270,9 @@ class XarrayCanvasIterDataPipe(IterDataPipe[Union[xr.DataArray, xr.Dataset]]):
                 plot_height=plot_height,
                 x_range=(xmin, xmax),
                 y_range=(ymin, ymax),
-                **self.kwargs
+                **self.kwargs,
             )
+            canvas.crs = dataarray.rio.crs
             yield canvas
 
     def __len__(self) -> int:

--- a/zen3geo/datapipes/datashader.py
+++ b/zen3geo/datapipes/datashader.py
@@ -31,7 +31,7 @@ class DatashaderRasterizerIterDataPipe(IterDataPipe):
     Takes vector :py:class:`geopandas.GeoSeries` or
     :py:class:`geopandas.GeoDataFrame` geometries and rasterizes them using
     :py:class:`datashader.Canvas` to yield an :py:class:`xarray.DataArray`
-    raster with input geometries aggregated into a fixed-sized grid
+    raster with the input geometries aggregated into a fixed-sized grid
     (functional name: ``rasterize_with_datashader``).
 
     Parameters
@@ -141,6 +141,11 @@ class DatashaderRasterizerIterDataPipe(IterDataPipe):
       * y            (y) float64 4.157e+05 3.47e+05 2.783e+05 ... 1.41e+05 7.237e+04
         spatial_ref  int64 0
     ...
+    >>> dataarray.rio.crs
+    CRS.from_epsg(32631)
+    >>> dataarray.rio.transform()
+    Affine(98871.00388807665, 0.0, 160000.0,
+           0.0, -68660.4193667199, 450000.0)
     """
 
     def __init__(

--- a/zen3geo/tests/test_datapipes_datashader.py
+++ b/zen3geo/tests/test_datapipes_datashader.py
@@ -115,7 +115,7 @@ def test_datashader_rasterize_missing_crs(geometries):
     assert len(dp_datashader) == 1
     it = iter(dp_datashader)
     with pytest.raises(
-        ValueError, match="Missing crs information for datashader.Canvas"
+        AttributeError, match="Missing crs information for datashader.Canvas"
     ):
         raster = next(it)
 
@@ -126,7 +126,7 @@ def test_datashader_rasterize_missing_crs(geometries):
 
     assert len(dp_datashader2) == 1
     it = iter(dp_datashader2)
-    with pytest.raises(ValueError, match="Missing crs information for input"):
+    with pytest.raises(AttributeError, match="Missing crs information for input"):
         raster = next(it)
 
 


### PR DESCRIPTION
An iterable-style DataPipe for turning vector geometries into raster grids! Uses [`datashader`](https://github.com/holoviz/datashader) to do the rasterization.

**Preview** at https://zen3geo--35.org.readthedocs.build/en/35/api.html#zen3geo.datapipes.DatashaderRasterizer

Part 2 out of 2 of superseding #32. Recall that 1st step (#34) was to define a canvas, and 2nd step (this PR) is to burn the vector (points/lines/polygons) onto that canvas via some aggregation function.

TODO:

- [x] Initial implementation of `DatashaderRasterizerIterDataPipe`
- [x] Add unit tests that test when input canvas and/or vector geometries don't have a proper `.crs`
- [x] Handle rasterizing lines and polygons
- [x] Document the default aggregration function for points/lines/polygons
- [x] Refactor unit tests to use common fixtures and geometries

Won't do:
- Support crs override? No, because
  - Typically, reprojecting the vector geometry (higher resolution) to the raster canvas (lower resolution) is the proper way.
  - If users do want a different projection system, it's better to let handle the raster reprojection logic at an earlier stage (i.e. before XarrayCanvasIterDataPipe or this DatashaderRasterizer)
  - Want to have less nested if-then statements in this already convoluted DatashaderRasterizer code. See 'Zen of Python'.