### PR TITLE
:mag: Show more levels for the in-page table of contents

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -31,6 +31,9 @@ sphinx:
   config:
     autodoc_typehints: 'description'
     html_show_copyright: false
+    html_theme_options:
+      # https://sphinx-book-theme.readthedocs.io/en/stable/customize/sidebar-secondary.html
+      show_toc_level: 3
     intersphinx_mapping:
       datashader:
         - 'https://datashader.org/'

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -7,7 +7,7 @@ author: The zen3geo Team
 # Force re-execution of notebooks on each build.
 # See https://jupyterbook.org/content/execute.html
 execute:
-  execute_notebooks: force
+  execute_notebooks: cache
 
 # Define the name of the latex output file for PDF builds
 latex:

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,5 +1,9 @@
 # API Reference
 
+```{contents}
+:local:
+```
+
 ## DataPipes
 
 ```{eval-rst}

--- a/docs/api.md
+++ b/docs/api.md
@@ -22,21 +22,21 @@
     :show-inheritance:
 ```
 
-### Rioxarray
-
-```{eval-rst}
-.. automodule:: zen3geo.datapipes.rioxarray
-.. autoclass:: zen3geo.datapipes.RioXarrayReader
-.. autoclass:: zen3geo.datapipes.rioxarray.RioXarrayReaderIterDataPipe
-    :show-inheritance:
-```
-
 ### Pyogrio
 
 ```{eval-rst}
 .. automodule:: zen3geo.datapipes.pyogrio
 .. autoclass:: zen3geo.datapipes.PyogrioReader
 .. autoclass:: zen3geo.datapipes.pyogrio.PyogrioReaderIterDataPipe
+    :show-inheritance:
+```
+
+### Rioxarray
+
+```{eval-rst}
+.. automodule:: zen3geo.datapipes.rioxarray
+.. autoclass:: zen3geo.datapipes.RioXarrayReader
+.. autoclass:: zen3geo.datapipes.rioxarray.RioXarrayReaderIterDataPipe
     :show-inheritance:
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,9 +1,5 @@
 # API Reference
 
-```{contents}
-:local:
-```
-
 ## DataPipes
 
 ```{eval-rst}


### PR DESCRIPTION
Making it easier to navigate to the desired subsection on https://zen3geo.readthedocs.io/en/v0.2.0/api.html. Also a few minor tweaks here are there.

**Preview** at https://zen3geo--36.org.readthedocs.build/en/36/api.html

| Before | After |
|--|--|
| ![image](https://user-images.githubusercontent.com/23487320/184554406-7aeb7d68-c724-4919-8c9b-6feaaa1d02a1.png) | ![image](https://user-images.githubusercontent.com/23487320/184554442-3c5e6c66-2dd3-4a07-bb54-84494d9738e8.png) |

References:
- https://sphinx-book-theme.readthedocs.io/en/stable/customize/sidebar-secondary.html