### PR TITLE
:adhesive_bandage: Raise ModuleNotFoundError when xbatcher not installed

### DIFF
--- a/zen3geo/datapipes/datashader.py
+++ b/zen3geo/datapipes/datashader.py
@@ -251,7 +251,7 @@ class XarrayCanvasIterDataPipe(IterDataPipe[Union[xr.DataArray, xr.Dataset]]):
 
     Parameters
     ----------
-    source_datapipe : IterDataPipe[xr.DataArray]
+    source_datapipe : IterDataPipe[xarrray.DataArray]
         A DataPipe that contains :py:class:`xarray.DataArray` or
         :py:class:`xarray.Dataset` objects. These data objects need to have
         both a ``.rio.x_dim`` and ``.rio.y_dim`` attribute, which is present

--- a/zen3geo/datapipes/xbatcher.py
+++ b/zen3geo/datapipes/xbatcher.py
@@ -22,7 +22,7 @@ class XbatcherSlicerIterDataPipe(IterDataPipe[Union[xr.DataArray, xr.Dataset]]):
 
     Parameters
     ----------
-    source_datapipe : IterDataPipe[xr.DataArray]
+    source_datapipe : IterDataPipe[xarray.DataArray]
         A DataPipe that contains :py:class:`xarray.DataArray` or
         :py:class:`xarray.Dataset` objects.
 

--- a/zen3geo/datapipes/xbatcher.py
+++ b/zen3geo/datapipes/xbatcher.py
@@ -85,6 +85,12 @@ class XbatcherSlicerIterDataPipe(IterDataPipe[Union[xr.DataArray, xr.Dataset]]):
         input_dims: Dict[Hashable, int],
         **kwargs: Optional[Dict[str, Any]]
     ) -> None:
+        if xbatcher is None:
+            raise ModuleNotFoundError(
+                "Package `xbatcher` is required to be installed to use this datapipe. "
+                "Please use `pip install xbatcher` "
+                "to install the package"
+            )
         self.source_datapipe: IterDataPipe[
             Union[xr.DataArray, xr.Dataset]
         ] = source_datapipe
@@ -105,5 +111,5 @@ class XbatcherSlicerIterDataPipe(IterDataPipe[Union[xr.DataArray, xr.Dataset]]):
             ):
                 yield chip
 
-        # def __len__(self) -> int:
-        #     return len(self.source_datapipe)
+    # def __len__(self) -> int:
+    #     return len(self.source_datapipe)


### PR DESCRIPTION
Ensure that a helpful ModuleNotFoundError is raised when attempting to use XbatcherSlicer without `xbatcher` being installed.

Patches #22