### PR TITLE
:recycle: Refactor DatashaderRasterizer to be up front about datapipe lengths

### DIFF
--- a/zen3geo/tests/test_datapipes_datashader.py
+++ b/zen3geo/tests/test_datapipes_datashader.py
@@ -139,10 +139,23 @@ def test_datashader_rasterize_vector_missing_crs(canvas, geodataframe):
         raster = next(it)
 
 
+def test_datashader_rasterize_unmatched_lengths(canvas, geodataframe):
+    """
+    Ensure that DatashaderRasterizer raises a ValueError when the length of the
+    canvas datapipe is unmatched with the length of the vector datapipe.
+    """
+    # Canvas:Vector ratio of 3:2
+    dp_canvas = IterableWrapper(iterable=[canvas, canvas, canvas])
+    dp_vector = IterableWrapper(iterable=[geodataframe, geodataframe])
+
+    with pytest.raises(ValueError, match="Unmatched lengths for the"):
+        dp_datashader = dp_canvas.rasterize_with_datashader(vector_datapipe=dp_vector)
+
+
 def test_datashader_rasterize_vector_geometrycollection(canvas, geodataframe):
     """
-    Ensure that DatashaderRasterizer raises a ValueError when an unsupported
-    vector type like GeometryCollection is used.
+    Ensure that DatashaderRasterizer raises a NotImplementedError when an
+    unsupported vector type like GeometryCollection is used.
     """
     gpd = pytest.importorskip("geopandas")
 
@@ -156,5 +169,5 @@ def test_datashader_rasterize_vector_geometrycollection(canvas, geodataframe):
 
     assert len(dp_datashader) == 1
     it = iter(dp_datashader)
-    with pytest.raises(ValueError, match="Unsupported geometry type"):
+    with pytest.raises(NotImplementedError, match="Unsupported geometry type"):
         raster = next(it)


### PR DESCRIPTION
Check during initialization of `DatashaderRasterizerIterDataPipe` on whether the input canvas and vector datapipes have compatible lengths. This is better than finding out that the zip function doesn't work when the datapipe is being iterated over. Added a unit test to cover the 3:2 ratio case and documented why the `ValueError` is raised on unmatched lengths. Also renamed the previous `ValueError` on unsupported geometry types to `NotImplementedError` to avoid confusion.

Motivated by issues discovered in #31 (see af489a8d9fecf1fd0241e5b62a7abdf0f0b2f0dd) when some DataPipe functions like https://pytorch.org/data/0.4/generated/torchdata.datapipes.iter.BatchMapper.html do not return any lengths.

Patches #35.