### PR TITLE
:memo: Improve pip install zen3geo instructions with extras dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ To install the development version from GitHub, do:
 
     pip install git+https://github.com/weiji14/zen3geo.git
 
-Or from [TestPyPI](https://test.pypi.org/project/zen3geo):
+Or the stable version from [PyPI](https://pypi.org/project/zen3geo):
 
-    pip install --pre --extra-index-url https://test.pypi.org/simple/ zen3geo
+    pip install zen3geo
+
+More detailed instructions at https://zen3geo.readthedocs.io/en/latest/#installation

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -94,6 +94,7 @@ but we welcome folks from across the world! Please reach out if you have experie
 
 ---
 
+(contributing:running:locally)=
 ## 🏠 Running things locally
 
 This project uses [``poetry``](https://python-poetry.org/docs/master/) for

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,10 +2,21 @@
 
 ## Installation
 
-To install the development version from GitHub, do:
+Get what you need, not more, not less:
 
-    pip install git+https://github.com/weiji14/zen3geo.git
+| Command                        |  Dependencies |
+|:-------------------------------|---------------|
+| `pip install zen3geo`          | rioxarray, torchdata |
+| `pip install zen3geo[raster]`  | rioxarray, torchdata, xbatcher |
+| `pip install zen3geo[spatial]` | rioxarray, torchdata, datashader, spatialpandas |
+| `pip install zen3geo[vector]`  | rioxarray, torchdata, pyogrio[geopandas] |
 
-Or from [TestPyPI](https://test.pypi.org/project/zen3geo):
+Retrieve more 'extras' using
+
+    pip install zen3geo[raster,spatial,vector]
+
+To install the development version from [TestPyPI](https://test.pypi.org/project/zen3geo), do:
 
     pip install --pre --extra-index-url https://test.pypi.org/simple/ zen3geo
+
+For the eager ones, {ref}`contributing <contributing:running:locally>` will take you further.


### PR DESCRIPTION
Made a table of all the possible 'extras' installation options, and what dependencies they come with. That's for the readthedocs index page. The GitHub installation instructions remains minimal, pointing to the detailed table instead for those seeking more.

**Preview** at https://zen3geo--40.org.readthedocs.build/en/40/index.html

| Command                        |  Dependencies |
|:-------------------------------|---------------|
| `pip install zen3geo`          | rioxarray, torchdata |
| `pip install zen3geo[raster]`  | rioxarray, torchdata, xbatcher |
| `pip install zen3geo[spatial]` | rioxarray, torchdata, datashader, spatialpandas |
| `pip install zen3geo[vector]`  | rioxarray, torchdata, pyogrio[geopandas] |