### PR TITLE
:sparkles: PySTACItemReaderIterDataPipe for reading STAC Items

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -47,6 +47,9 @@ sphinx:
       pyogrio:
         - 'https://pyogrio.readthedocs.io/en/latest/'
         - null
+      pystac:
+        - 'https://pystac.readthedocs.io/en/latest/'
+        - null
       python:
         - 'https://docs.python.org/3/'
         - null

--- a/docs/api.md
+++ b/docs/api.md
@@ -27,6 +27,15 @@
     :show-inheritance:
 ```
 
+### PySTAC
+
+```{eval-rst}
+.. automodule:: zen3geo.datapipes.pystac
+.. autoclass:: zen3geo.datapipes.PySTACItemReader
+.. autoclass:: zen3geo.datapipes.pystac.PySTACItemReaderIterDataPipe
+    :show-inheritance:
+```
+
 ### Rioxarray
 
 ```{eval-rst}

--- a/poetry.lock
+++ b/poetry.lock
@@ -104,9 +104,9 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.extras]
-dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six", "sphinx", "sphinx-notfound-page", "zope-interface"]
-docs = ["furo", "sphinx", "sphinx-notfound-page", "zope-interface"]
-tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six", "zope-interface"]
+dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six", "sphinx", "sphinx-notfound-page", "zope.interface"]
+docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
+tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six", "zope.interface"]
 tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six"]
 
 [[package]]
@@ -601,7 +601,7 @@ optional = true
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
 
 [package.extras]
-docs = ["sphinx"]
+docs = ["Sphinx"]
 
 [[package]]
 name = "heapdict"
@@ -641,7 +641,7 @@ zipp = ">=0.5"
 [package.extras]
 docs = ["jaraco.packaging (>=9)", "rst.linker (>=1.9)", "sphinx"]
 perf = ["ipython"]
-testing = ["flufl-flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)"]
+testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)"]
 
 [[package]]
 name = "importlib-resources"
@@ -831,8 +831,8 @@ sphinxcontrib-bibtex = ">=2.2.0,<=2.5.0"
 [package.extras]
 code_style = ["pre-commit (>=2.12,<3.0)"]
 pdfhtml = ["pyppeteer"]
-sphinx = ["altair", "bokeh", "folium", "ipywidgets", "jupytext", "matplotlib", "nbclient", "numpy", "pandas", "plotly", "sphinx-click", "sphinx-examples", "sphinx-inline-tabs", "sphinx-proof", "sphinxext-rediraffe (>=0.2.3,<0.3.0)", "sympy"]
-testing = ["altair", "beautifulsoup4", "beautifulsoup4", "cookiecutter", "coverage", "jupytext", "matplotlib", "pyppeteer", "pytest (>=6.2.4)", "pytest-cov", "pytest-regressions", "pytest-timeout", "pytest-xdist", "sphinx-click", "sphinx-tabs", "texsoup"]
+sphinx = ["altair", "bokeh", "folium", "ipywidgets", "jupytext", "matplotlib", "nbclient", "numpy", "pandas", "plotly", "sphinx-click", "sphinx-examples", "sphinx-proof", "sphinx_inline_tabs", "sphinxext-rediraffe (>=0.2.3,<0.3.0)", "sympy"]
+testing = ["altair", "beautifulsoup4", "beautifulsoup4", "cookiecutter", "coverage", "jupytext", "matplotlib", "pyppeteer", "pytest (>=6.2.4)", "pytest-cov", "pytest-regressions", "pytest-timeout", "pytest-xdist", "sphinx_click", "sphinx_tabs", "texsoup"]
 
 [[package]]
 name = "jupyter-cache"
@@ -932,7 +932,7 @@ python-versions = ">=3.7"
 jupyter-server = ">=1.1,<2.0"
 
 [package.extras]
-test = ["jupyter-server", "pytest"]
+test = ["jupyter-server[test]", "pytest"]
 
 [[package]]
 name = "jupyter-sphinx"
@@ -1261,7 +1261,7 @@ tornado = "*"
 
 [package.extras]
 docs = ["recommonmark", "sphinx", "sphinx-rtd-theme"]
-test = ["jsonschema", "jupyter-server", "mock", "notebook", "pytest (>=3.6)", "pytest-cov", "pytest-timeout", "pytest-tornado", "requests", "tabulate"]
+test = ["jsonschema", "jupyter-server[test]", "mock", "notebook", "pytest (>=3.6)", "pytest-cov", "pytest-timeout", "pytest-tornado", "requests", "tabulate"]
 
 [[package]]
 name = "nbformat"
@@ -1670,10 +1670,10 @@ packaging = "*"
 sphinx = ">=3.5.4,<5"
 
 [package.extras]
-coverage = ["codecov", "pydata-sphinx-theme", "pytest-cov"]
-dev = ["nox", "pre-commit", "pydata-sphinx-theme", "pyyaml"]
-doc = ["jupyter-sphinx", "myst-parser", "numpy", "numpydoc", "pandas", "plotly", "pytest", "pytest-regressions", "sphinx-sitemap", "sphinxext-rediraffe", "xarray"]
-test = ["pydata-sphinx-theme", "pytest"]
+coverage = ["codecov", "pydata-sphinx-theme[test]", "pytest-cov"]
+dev = ["nox", "pre-commit", "pydata-sphinx-theme[coverage]", "pyyaml"]
+doc = ["jupyter_sphinx", "myst-parser", "numpy", "numpydoc", "pandas", "plotly", "pytest", "pytest-regressions", "sphinx-sitemap", "sphinxext-rediraffe", "xarray"]
+test = ["pydata-sphinx-theme[doc]", "pytest"]
 
 [[package]]
 name = "pygeos"
@@ -1714,7 +1714,7 @@ pygeos = {version = "*", optional = true, markers = "extra == \"geopandas\""}
 
 [package.extras]
 benchmark = ["pytest-benchmark"]
-dev = ["cython"]
+dev = ["Cython"]
 geopandas = ["geopandas", "pygeos"]
 test = ["pytest", "pytest-cov"]
 
@@ -1945,9 +1945,9 @@ rasterio = ">=1.1.1"
 xarray = ">=0.17"
 
 [package.extras]
-all = ["dask", "mypy", "nbsphinx", "netcdf4", "pre-commit", "pylint", "pytest (>=3.6)", "pytest-cov", "pytest-timeout", "scipy", "sphinx-click", "sphinx-rtd-theme"]
-dev = ["dask", "mypy", "nbsphinx", "netcdf4", "pre-commit", "pylint", "pytest (>=3.6)", "pytest-cov", "pytest-timeout", "scipy", "sphinx-click", "sphinx-rtd-theme"]
-doc = ["nbsphinx", "sphinx-click", "sphinx-rtd-theme"]
+all = ["dask", "mypy", "nbsphinx", "netcdf4", "pre-commit", "pylint", "pytest (>=3.6)", "pytest-cov", "pytest-timeout", "scipy", "sphinx-click", "sphinx_rtd_theme"]
+dev = ["dask", "mypy", "nbsphinx", "netcdf4", "pre-commit", "pylint", "pytest (>=3.6)", "pytest-cov", "pytest-timeout", "scipy", "sphinx-click", "sphinx_rtd_theme"]
+doc = ["nbsphinx", "sphinx-click", "sphinx_rtd_theme"]
 interp = ["scipy"]
 test = ["dask", "netcdf4", "pytest (>=3.6)", "pytest-cov", "pytest-timeout"]
 
@@ -1971,8 +1971,8 @@ optional = true
 python-versions = "*"
 
 [package.extras]
-nativelib = ["pyobjc-framework-cocoa", "pywin32"]
-objc = ["pyobjc-framework-cocoa"]
+nativelib = ["pyobjc-framework-Cocoa", "pywin32"]
+objc = ["pyobjc-framework-Cocoa"]
 win32 = ["pywin32"]
 
 [[package]]
@@ -1985,8 +1985,8 @@ python-versions = ">=3.7"
 
 [package.extras]
 docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mock", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
-testing-integration = ["build", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mock", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
 name = "setuptools-scm"
@@ -2151,7 +2151,7 @@ sphinx = ">=3,<5"
 [package.extras]
 code_style = ["pre-commit (>=2.7.0,<2.8.0)"]
 doc = ["ablog (>=0.10.13,<0.11.0)", "folium", "ipywidgets", "matplotlib", "myst-nb (>=0.13,<1.0)", "nbclient", "numpy", "numpydoc", "pandas", "plotly", "sphinx (>=4.0,<5.0)", "sphinx-copybutton", "sphinx-design", "sphinx-tabs", "sphinx-thebe (>=0.1.1)", "sphinx-togglebutton (>=0.2.1)", "sphinxcontrib-bibtex (>=2.2,<3.0)", "sphinxcontrib-youtube", "sphinxext-opengraph"]
-test = ["beautifulsoup4 (>=4.6.1,<5)", "coverage", "myst_nb (>=0.13,<1.0)", "pytest (>=6.0.1,<6.1.0)", "pytest-cov", "pytest-regressions (>=2.0.1,<2.1.0)", "sphinx-thebe"]
+test = ["beautifulsoup4 (>=4.6.1,<5)", "coverage", "myst_nb (>=0.13,<1.0)", "pytest (>=6.0.1,<6.1.0)", "pytest-cov", "pytest-regressions (>=2.0.1,<2.1.0)", "sphinx_thebe"]
 
 [[package]]
 name = "sphinx-comments"
@@ -2404,7 +2404,7 @@ postgresql_pg8000 = ["pg8000 (>=1.16.6,!=1.29.0)"]
 postgresql_psycopg2binary = ["psycopg2-binary"]
 postgresql_psycopg2cffi = ["psycopg2cffi"]
 pymysql = ["pymysql", "pymysql (<1)"]
-sqlcipher = ["sqlcipher3-binary"]
+sqlcipher = ["sqlcipher3_binary"]
 
 [[package]]
 name = "stack-data"
@@ -2458,8 +2458,8 @@ python-versions = ">=3.6"
 webencodings = ">=0.4"
 
 [package.extras]
-doc = ["sphinx", "sphinx-rtd-theme"]
-test = ["coverage", "pytest", "pytest-cov", "pytest-flake8", "pytest-isort"]
+doc = ["sphinx", "sphinx_rtd_theme"]
+test = ["coverage[toml]", "pytest", "pytest-cov", "pytest-flake8", "pytest-isort"]
 
 [[package]]
 name = "tomli"
@@ -2619,10 +2619,10 @@ pandas = ">=1.1"
 
 [package.extras]
 accel = ["bottleneck", "numbagg", "scipy"]
-complete = ["bottleneck", "cfgrib", "cftime", "dask", "fsspec", "h5netcdf", "matplotlib", "nc-time-axis", "netcdf4", "numbagg", "pooch", "pydap", "rasterio", "scipy", "seaborn", "zarr"]
-docs = ["bottleneck", "cfgrib", "cftime", "dask", "fsspec", "h5netcdf", "ipykernel", "ipython", "jupyter-client", "matplotlib", "nbsphinx", "nc-time-axis", "netcdf4", "numbagg", "pooch", "pydap", "rasterio", "scanpydoc", "scipy", "seaborn", "sphinx-autosummary-accessors", "sphinx-rtd-theme", "zarr"]
-io = ["cfgrib", "cftime", "fsspec", "h5netcdf", "netcdf4", "pooch", "pydap", "rasterio", "scipy", "zarr"]
-parallel = ["dask"]
+complete = ["bottleneck", "cfgrib", "cftime", "dask[complete]", "fsspec", "h5netcdf", "matplotlib", "nc-time-axis", "netCDF4", "numbagg", "pooch", "pydap", "rasterio", "scipy", "seaborn", "zarr"]
+docs = ["bottleneck", "cfgrib", "cftime", "dask[complete]", "fsspec", "h5netcdf", "ipykernel", "ipython", "jupyter-client", "matplotlib", "nbsphinx", "nc-time-axis", "netCDF4", "numbagg", "pooch", "pydap", "rasterio", "scanpydoc", "scipy", "seaborn", "sphinx-autosummary-accessors", "sphinx-rtd-theme", "zarr"]
+io = ["cfgrib", "cftime", "fsspec", "h5netcdf", "netCDF4", "pooch", "pydap", "rasterio", "scipy", "zarr"]
+parallel = ["dask[complete]"]
 viz = ["matplotlib", "nc-time-axis", "seaborn"]
 
 [[package]]
@@ -2659,18 +2659,18 @@ python-versions = ">=3.7"
 
 [package.extras]
 docs = ["jaraco.packaging (>=9)", "rst.linker (>=1.9)", "sphinx"]
-testing = ["func-timeout", "jaraco-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
+testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [extras]
 docs = ["datashader", "graphviz", "jupyter-book", "matplotlib", "planetary-computer", "pyogrio", "pystac", "spatialpandas", "xbatcher"]
 raster = ["xbatcher"]
-spatial = ["datashader", "spatialpandas"]
+spatial = ["datashader", "pystac", "spatialpandas"]
 vector = ["pyogrio"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8, <3.12"
-content-hash = "ce71899fd3579a202d8da58540cfac40ea1f35f124f072e79641a37a078ff2e8"
+content-hash = "64aaed70c57163aeeb6705026d4f314ef7fd918c40ac495d1b4fbac1a80ffe07"
 
 [metadata.files]
 affine = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ docs = [
 raster = ["xbatcher"]
 spatial = [
     "datashader",
+    "pystac",
     "spatialpandas"
 ]
 vector = ["pyogrio"]

--- a/zen3geo/datapipes/__init__.py
+++ b/zen3geo/datapipes/__init__.py
@@ -7,5 +7,6 @@ from zen3geo.datapipes.datashader import (
     XarrayCanvasIterDataPipe as XarrayCanvas,
 )
 from zen3geo.datapipes.pyogrio import PyogrioReaderIterDataPipe as PyogrioReader
+from zen3geo.datapipes.pystac import PySTACItemReaderIterDataPipe as PySTACItemReader
 from zen3geo.datapipes.rioxarray import RioXarrayReaderIterDataPipe as RioXarrayReader
 from zen3geo.datapipes.xbatcher import XbatcherSlicerIterDataPipe as XbatcherSlicer

--- a/zen3geo/datapipes/pystac.py
+++ b/zen3geo/datapipes/pystac.py
@@ -1,0 +1,75 @@
+"""
+DataPipes for :doc:`pystac <pystac:index>`.
+"""
+from typing import Any, Dict, Iterator, Optional
+
+import pystac
+from torchdata.datapipes import functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe
+
+
+@functional_datapipe("read_from_pystac_item")
+class PySTACItemReaderIterDataPipe(IterDataPipe):
+    """
+    Takes files from local disk or URLs (as long as they can be read by pystac)
+    and yields :py:class:`pystac.item.Item` objects (functional name:
+    ``read_from_pystac_item``).
+
+    Parameters
+    ----------
+    source_datapipe : IterDataPipe[str]
+        A DataPipe that contains filepaths or URL links to STAC items.
+
+    kwargs : Optional
+        Extra keyword arguments to pass to :py:meth:`pystac.Item.from_file`.
+
+    Yields
+    ------
+    stream_obj : pystac.item.Item
+        An :py:class:`pystac.item.Item` object containing the specific
+        STACObject implementation class represented in a JSON format.
+
+    Example
+    -------
+    >>> from torchdata.datapipes.iter import IterableWrapper
+    >>> from zen3geo.datapipes import PySTACItemReader
+    ...
+    >>> # Read in STAC Item using DataPipe
+    >>> item_url: str = "https://planetarycomputer.microsoft.com/api/stac/v1/collections/sentinel-2-l2a/items/S2A_MSIL2A_20220115T032101_R118_T48NUG_20220115T170435"
+    >>> dp = IterableWrapper(iterable=[item_url])
+    >>> dp_pystac = dp.read_from_pystac_item()
+    ...
+    >>> # Loop or iterate over the DataPipe stream
+    >>> it = iter(dp_pystac)
+    >>> stac_item = next(it)
+    >>> stac_item.bbox
+    [103.20205689, 0.81602476, 104.18934086, 1.8096362]
+    >>> stac_item.properties  # doctest: +NORMALIZE_WHITESPACE
+    {'datetime': '2022-01-15T03:21:01.024000Z',
+     'platform': 'Sentinel-2A',
+     'proj:epsg': 32648,
+     'instruments': ['msi'],
+     's2:mgrs_tile': '48NUG',
+     'constellation': 'Sentinel 2',
+     's2:granule_id': 'S2A_OPER_MSI_L2A_TL_ESRI_20220115T170436_A034292_T48NUG_N03.00',
+     'eo:cloud_cover': 17.352597,
+     's2:datatake_id': 'GS2A_20220115T032101_034292_N03.00',
+     's2:product_uri': 'S2A_MSIL2A_20220115T032101_N0300_R118_T48NUG_20220115T170435.SAFE',
+     's2:datastrip_id': 'S2A_OPER_MSI_L2A_DS_ESRI_20220115T170436_S20220115T033502_N03.00',
+     's2:product_type': 'S2MSI2A',
+     'sat:orbit_state': 'descending',
+    ...
+    """
+
+    def __init__(
+        self, source_datapipe: IterDataPipe[str], **kwargs: Optional[Dict[str, Any]]
+    ) -> None:
+        self.source_datapipe: IterDataPipe[str] = source_datapipe
+        self.kwargs = kwargs
+
+    def __iter__(self) -> Iterator:
+        for href in self.source_datapipe:
+            yield pystac.Item.from_file(href=href, **self.kwargs)
+
+    def __len__(self) -> int:
+        return len(self.source_datapipe)

--- a/zen3geo/datapipes/pystac.py
+++ b/zen3geo/datapipes/pystac.py
@@ -41,6 +41,9 @@ class PySTACItemReaderIterDataPipe(IterDataPipe):
 
     Example
     -------
+    >>> import pytest
+    >>> pystac = pytest.importorskip("pystac")
+    ...
     >>> from torchdata.datapipes.iter import IterableWrapper
     >>> from zen3geo.datapipes import PySTACItemReader
     ...

--- a/zen3geo/datapipes/pystac.py
+++ b/zen3geo/datapipes/pystac.py
@@ -11,12 +11,12 @@ from torchdata.datapipes import functional_datapipe
 from torchdata.datapipes.iter import IterDataPipe
 
 
-@functional_datapipe("read_from_pystac_item")
+@functional_datapipe("read_to_pystac_item")
 class PySTACItemReaderIterDataPipe(IterDataPipe):
     """
     Takes files from local disk or URLs (as long as they can be read by pystac)
-    and yields :py:class:`pystac.item.Item` objects (functional name:
-    ``read_from_pystac_item``).
+    and yields :py:class:`pystac.Item` objects (functional name:
+    ``read_to_pystac_item``).
 
     Parameters
     ----------
@@ -28,9 +28,9 @@ class PySTACItemReaderIterDataPipe(IterDataPipe):
 
     Yields
     ------
-    stream_obj : pystac.item.Item
-        An :py:class:`pystac.item.Item` object containing the specific
-        STACObject implementation class represented in a JSON format.
+    stac_item : pystac.Item
+        An :py:class:`pystac.Item` object containing the specific STACObject
+        implementation class represented in a JSON format.
 
     Raises
     ------
@@ -47,7 +47,7 @@ class PySTACItemReaderIterDataPipe(IterDataPipe):
     >>> # Read in STAC Item using DataPipe
     >>> item_url: str = "https://planetarycomputer.microsoft.com/api/stac/v1/collections/sentinel-2-l2a/items/S2A_MSIL2A_20220115T032101_R118_T48NUG_20220115T170435"
     >>> dp = IterableWrapper(iterable=[item_url])
-    >>> dp_pystac = dp.read_from_pystac_item()
+    >>> dp_pystac = dp.read_to_pystac_item()
     ...
     >>> # Loop or iterate over the DataPipe stream
     >>> it = iter(dp_pystac)

--- a/zen3geo/datapipes/pystac.py
+++ b/zen3geo/datapipes/pystac.py
@@ -3,7 +3,10 @@ DataPipes for :doc:`pystac <pystac:index>`.
 """
 from typing import Any, Dict, Iterator, Optional
 
-import pystac
+try:
+    import pystac
+except ImportError:
+    pystac = None
 from torchdata.datapipes import functional_datapipe
 from torchdata.datapipes.iter import IterDataPipe
 
@@ -28,6 +31,13 @@ class PySTACItemReaderIterDataPipe(IterDataPipe):
     stream_obj : pystac.item.Item
         An :py:class:`pystac.item.Item` object containing the specific
         STACObject implementation class represented in a JSON format.
+
+    Raises
+    ------
+    ModuleNotFoundError
+        If ``pystac`` is not installed. See
+        :doc:`install instructions for pystac <pystac:installation>`, (e.g. via
+        ``pip install pystac``) before using this class.
 
     Example
     -------
@@ -64,6 +74,13 @@ class PySTACItemReaderIterDataPipe(IterDataPipe):
     def __init__(
         self, source_datapipe: IterDataPipe[str], **kwargs: Optional[Dict[str, Any]]
     ) -> None:
+        if pystac is None:
+            raise ModuleNotFoundError(
+                "Package `pystac` is required to be installed to use this datapipe. "
+                "Please use `pip install pystac` or "
+                "`conda install -c conda-forge pystac` "
+                "to install the package"
+            )
         self.source_datapipe: IterDataPipe[str] = source_datapipe
         self.kwargs = kwargs
 

--- a/zen3geo/tests/test_datapipes_pystac.py
+++ b/zen3geo/tests/test_datapipes_pystac.py
@@ -1,0 +1,47 @@
+"""
+Tests for pystac datapipes.
+"""
+import pytest
+from torchdata.datapipes.iter import IterableWrapper
+
+from zen3geo.datapipes import PySTACItemReader
+
+pystac = pytest.importorskip("pystac")
+
+# %%
+def test_pystac_item_reader():
+    """
+    Ensure that PySTACItemReader works to read in a JSON STAC item and outputs
+    to a pystac.Item object.
+    """
+    item_url: str = "https://github.com/stac-utils/pystac/raw/v1.6.1/tests/data-files/item/sample-item.json"
+    dp = IterableWrapper(iterable=[item_url])
+
+    # Using class constructors
+    dp_pystac = PySTACItemReader(source_datapipe=dp)
+    # Using functional form (recommended)
+    dp_pystac = dp.read_to_pystac_item()
+
+    assert len(dp_pystac) == 1
+    it = iter(dp_pystac)
+    stac_item = next(it)
+
+    assert stac_item.bbox == [-122.59750209, 37.48803556, -122.2880486, 37.613537207]
+    assert stac_item.datetime.isoformat() == "2016-05-03T13:22:30.040000+00:00"
+    assert stac_item.geometry["type"] == "Polygon"
+    assert stac_item.properties == {
+        "datetime": "2016-05-03T13:22:30.040000Z",
+        "title": "A CS3 item",
+        "license": "PDDL-1.0",
+        "providers": [
+            {
+                "name": "CoolSat",
+                "roles": ["producer", "licensor"],
+                "url": "https://cool-sat.com/",
+            }
+        ],
+    }
+    assert (
+        stac_item.assets["analytic"].extra_fields["product"]
+        == "http://cool-sat.com/catalog/products/analytic.json"
+    )


### PR DESCRIPTION
An iterable-style DataPipe for [STAC](https://stacspec.org) items! Uses [pystac](https://github.com/stac-utils/pystac) for reading the files or URLs.

**Preview** at https://zen3geo--46.org.readthedocs.build/en/46/api.html#zen3geo.datapipes.PySTACItemReader

Usage

```python
from torchdata.datapipes.iter import IterableWrapper
from zen3geo.datapipes import PySTACItemReader

# Read in STAC Item using DataPipe
item_url: str = "https://planetarycomputer.microsoft.com/api/stac/v1/collections/sentinel-2-l2a/items/S2A_MSIL2A_20220115T032101_R118_T48NUG_20220115T170435"
dp = IterableWrapper(iterable=[item_url])
dp_pystac = dp.read_to_pystac_item()

# Loop or iterate over the DataPipe stream
it = iter(dp_pystac)
stac_item = next(it)

print(stac_item.bbox)
# [103.20205689, 0.81602476, 104.18934086, 1.8096362]

print(stac_item.properties)
# {'datetime': '2022-01-15T03:21:01.024000Z',
#  'platform': 'Sentinel-2A',
#  'proj:epsg': 32648,
#  'instruments': ['msi'],
#  's2:mgrs_tile': '48NUG',
#  'constellation': 'Sentinel 2',
#  's2:granule_id': 'S2A_OPER_MSI_L2A_TL_ESRI_20220115T170436_A034292_T48NUG_N03.00',
#  'eo:cloud_cover': 17.352597,
#  's2:datatake_id': 'GS2A_20220115T032101_034292_N03.00',
#  's2:product_uri': 'S2A_MSIL2A_20220115T032101_N0300_R118_T48NUG_20220115T170435.SAFE',
#  's2:datastrip_id': 'S2A_OPER_MSI_L2A_DS_ESRI_20220115T170436_S20220115T033502_N03.00',
#  's2:product_type': 'S2MSI2A',
#  'sat:orbit_state': 'descending',
#  ...
```

This `dp_pystac` DataPipe could then be chained to [`RioxarrayReader`](https://zen3geo.readthedocs.io/en/v0.3.0/api.html#zen3geo.datapipes.RioXarrayReader) to load the data into an `xarray.DataArray`, see walkthrough at https://zen3geo.readthedocs.io/en/v0.3.0/walkthrough.html#find-cloud-optimized-geotiffs.

TODO:
- [x] Initial implementation with a doctest that checks the metadata within the [pystac.item.Item](https://pystac.readthedocs.io/en/1.0/api/item.html) object.
- [x] Add unit tests
- [ ] etc

Part of #48.

References:
- https://github.com/microsoft/torchgeo/pull/412