### PR TITLE
:pencil2: Fix broken torchdata links by using intersphinx properly

### DIFF
--- a/docs/chipping.md
+++ b/docs/chipping.md
@@ -12,6 +12,10 @@ kernelspec:
 
 # Chipping and batching data
 
+> What is separation?
+>
+> What isn't?
+
 Following on from the previous tutorial,
 let's 🧑‍🎓 learn more about creating a more complicated 🌈 raster data pipeline.
 Specifically, we'll go through the following:

--- a/docs/vector-segmentation-masks.md
+++ b/docs/vector-segmentation-masks.md
@@ -327,9 +327,9 @@ mask, we have an easy 1:1 mapping. There are two other scenarios supported by
 For more details on how rasterization of polygons work behind the scenes 🎦,
 check out {doc}`Datashader <datashader:index>`'s documentation on:
 
-- {doc}`The datashader pipeline <getting_started/Pipeline>` (especially the
-  section on Aggregation).
-- {doc}`Rendering large collections of polygons <user_guide/Polygons>`
+- {doc}`The datashader pipeline <datashader:getting_started/Pipeline>`
+  (especially the section on Aggregation).
+- {doc}`Rendering large collections of polygons <datashader:user_guide/Polygons>`
 ```
 
 

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -132,7 +132,7 @@ dp_rioxarray
 
 Note that both ways are equivalent (they produce the same IterDataPipe output),
 but the latter (functional) form is preferred, see also
-https://pytorch.org/data/0.4.0/tutorial.html#registering-datapipes-with-the-functional-api
+https://pytorch.org/data/0.4/tutorial.html#registering-datapipes-with-the-functional-api
 
 What if you don't want the whole Sentinel-2 scene at the full 10m resolution?
 Since we're using Cloud-Optimized GeoTIFFs, you could set an ``overview_level``
@@ -211,8 +211,8 @@ And so it begins 🌄
 
 That’s all 🎉! For more information on how to use DataPipes, check out:
 
-- Tutorial at https://pytorch.org/data/0.4.0/tutorial.html
-- Usage examples at https://pytorch.org/data/0.4.0/examples.html
+- {doc}`TorchData Tutorials <torchdata:tutorial>`
+- {doc}`TorchData Usage Examples <torchdata:examples>`
 
 If you have any questions 🙋, feel free to ask us anything at
 https://github.com/weiji14/zen3geo/discussions or visit the Pytorch forums at


### PR DESCRIPTION
Noticed some torchdata links got changed from https://pytorch.org/data/0.4.0 to https://pytorch.org/data/0.4, and also making some minor documentation improvements here and there.

References:
- https://docs.readthedocs.io/en/stable/guides/intersphinx.html
- https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html