### PR TITLE
:sparkles: GeoPandasRectangleClipper for spatially subsetting vectors

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -18,6 +18,15 @@
     :show-inheritance:
 ```
 
+### Geopandas
+
+```{eval-rst}
+.. automodule:: zen3geo.datapipes.geopandas
+.. autoclass:: zen3geo.datapipes.GeoPandasRectangleClipper
+.. autoclass:: zen3geo.datapipes.geopandas.GeoPandasRectangleClipperIterDataPipe
+    :show-inheritance:
+```
+
 ### Pyogrio
 
 ```{eval-rst}

--- a/zen3geo/datapipes/__init__.py
+++ b/zen3geo/datapipes/__init__.py
@@ -6,6 +6,9 @@ from zen3geo.datapipes.datashader import (
     DatashaderRasterizerIterDataPipe as DatashaderRasterizer,
     XarrayCanvasIterDataPipe as XarrayCanvas,
 )
+from zen3geo.datapipes.geopandas import (
+    GeoPandasRectangleClipperIterDataPipe as GeoPandasRectangleClipper,
+)
 from zen3geo.datapipes.pyogrio import PyogrioReaderIterDataPipe as PyogrioReader
 from zen3geo.datapipes.rioxarray import RioXarrayReaderIterDataPipe as RioXarrayReader
 from zen3geo.datapipes.xbatcher import XbatcherSlicerIterDataPipe as XbatcherSlicer

--- a/zen3geo/datapipes/geopandas.py
+++ b/zen3geo/datapipes/geopandas.py
@@ -1,0 +1,163 @@
+"""
+DataPipes for :doc:`geopandas <geopandas:index>`.
+"""
+from typing import Any, Dict, Iterator, Optional
+
+try:
+    import geopandas as gpd
+except ImportError:
+    gpd = None
+import xarray as xr
+from torchdata.datapipes import functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe
+
+
+@functional_datapipe("clip_vector_with_rectangle")
+class GeoPandasRectangleClipperIterDataPipe(IterDataPipe):
+    """
+    Takes vector :py:class:`geopandas.GeoSeries` or
+    :py:class:`geopandas.GeoDataFrame` geometries and clips them with the
+    rectangular extent of an :py:class:`xarray.DataArray` or
+    :py:class:`xarray.Dataset` grid to yield tuples of spatially subsetted
+    :py:class:`geopandas.GeoSeries` or :py:class:`geopandas.GeoDataFrame`
+    vectors and the correponding :py:class:`xarray.DataArray` or
+    :py:class:`xarray.Dataset` raster object used as the clip mask (functional
+    name: ``clip_vector_with_rectangle``).
+
+    Note that this uses the rectangular clip algorithm of
+    :py:func:`geopandas.clip`, with the bounding box rectangle (minx, miny,
+    maxx, maxy) derived from input raster mask's bounding box extent.
+
+    Parameters
+    ----------
+    source_datapipe : IterDataPipe[geopandas.GeoDataFrame]
+        A DataPipe that contains :py:class:`geopandas.GeoSeries` or
+        :py:class:`geopandas.GeoDataFrame` vector geometries with a ``.crs``
+        attribute.
+
+    mask_datapipe : IterDataPipe[xarray.DataArray]
+        A DataPipe that contains :py:class:`xarray.DataArray` or
+        :py:class:`xarray.Dataset` objects with a
+        :py:meth:`.rio.bounds <rioxarray.rioxarray.XRasterBase.bounds>` method.
+
+    kwargs : Optional
+        Extra keyword arguments to pass to :py:func:`geopandas.clip`.
+
+    Yields
+    ------
+    paired_obj : Tuple[geopandas.GeoDataFrame, xarray.DataArray]
+        A tuple consisting of the spatially subsetted
+        :py:class:`geopandas.GeoSeries` or :py:class:`geopandas.GeoDataFrame`
+        vector, and the corresponding :py:class:`xarray.DataArray` or
+        :py:class:`xarray.Dataset` raster used as the clip mask.
+
+    Raises
+    ------
+    ModuleNotFoundError
+        If ``geopandas`` is not installed. See
+        :doc:`install instructions for geopandas <geopandas:getting_started/install>`
+        (e.g. via ``pip install geopandas``) before using this class.
+
+    NotImplementedError
+        If the length of the vector ``source_datapipe`` is not 1. Currently,
+        all of the vector geometries have to be merged into a single
+        :py:class:`geopandas.GeoSeries` or :py:class:`geopandas.GeoDataFrame`.
+        Refer to the section on Appending under geopandas'
+        :doc:`geopandas:docs/user_guide/mergingdata` docs.
+
+    Example
+    -------
+    >>> import pytest
+    >>> import rioxarray
+    >>> gpd = pytest.importorskip("geopandas")
+    ...
+    >>> from torchdata.datapipes.iter import IterableWrapper
+    >>> from zen3geo.datapipes import GeoPandasRectangleClipper
+    ...
+    >>> # Read in a vector polygon data source
+    >>> geodataframe = gpd.read_file(
+    ...     filename="https://github.com/geopandas/geopandas/raw/v0.11.1/geopandas/tests/data/overlay/polys/df1.geojson",
+    ... )
+    >>> assert geodataframe.crs == "EPSG:4326"  # latitude/longitude coords
+    >>> dp_vector = IterableWrapper(iterable=[geodataframe])
+    ...
+    >>> # Get list of raster grids to cut up the vector polygon later
+    >>> dataarray = rioxarray.open_rasterio(
+    ...     filename="https://github.com/rasterio/rasterio/raw/1.3.2/tests/data/world.byte.tif"
+    ... )
+    >>> assert dataarray.rio.crs == "EPSG:4326"  # latitude/longitude coords
+    >>> dp_raster = IterableWrapper(
+    ...     iterable=[
+    ...         dataarray.sel(x=slice(0, 2)),  # longitude 0 to 2 degrees
+    ...         dataarray.sel(x=slice(2, 4)),  # longitude 2 to 4 degrees
+    ...     ]
+    ... )
+    ...
+    >>> # Clip vector point geometries based on raster masks
+    >>> dp_clipped = dp_vector.clip_vector_with_rectangle(
+    ...     mask_datapipe=dp_raster
+    ... )
+    ...
+    >>> # Loop or iterate over the DataPipe stream
+    >>> it = iter(dp_clipped)
+    >>> geodataframe0, raster0 = next(it)
+    >>> geodataframe0
+       col1                                           geometry
+    0     1  POLYGON ((0.00000 0.00000, 0.00000 2.00000, 2....
+    >>> raster0
+    <xarray.DataArray (band: 1, y: 1200, x: 16)>
+    array([[[0, 0, ..., 0, 0],
+            [0, 0, ..., 0, 0],
+            ...,
+            [1, 1, ..., 1, 1],
+            [1, 1, ..., 1, 1]]], dtype=uint8)
+    Coordinates:
+      * band         (band) int64 1
+      * x            (x) float64 0.0625 0.1875 0.3125 0.4375 ... 1.688 1.812 1.938
+      * y            (y) float64 74.94 74.81 74.69 74.56 ... -74.69 -74.81 -74.94
+        spatial_ref  int64 0
+    ...
+    >>> geodataframe1, raster1 = next(it)
+    >>> geodataframe1
+       col1                                           geometry
+    1     2  POLYGON ((2.00000 2.00000, 2.00000 4.00000, 4....
+    """
+
+    def __init__(
+        self,
+        source_datapipe: IterDataPipe,
+        mask_datapipe: IterDataPipe[xr.DataArray],
+        **kwargs: Optional[Dict[str, Any]],
+    ) -> None:
+        if gpd is None:
+            raise ModuleNotFoundError(
+                "Package `geopandas` is required to be installed to use this datapipe. "
+                "Please use `pip install geopandas` or "
+                "`conda install -c conda-forge geopandas` "
+                "to install the package"
+            )
+        self.source_datapipe: IterDataPipe = source_datapipe
+        self.mask_datapipe: IterDataPipe[xr.DataArray] = mask_datapipe
+        self.kwargs = kwargs
+
+        len_vector_datapipe: int = len(self.source_datapipe)
+        if len_vector_datapipe != 1:
+            raise NotImplementedError(
+                f"The vector datapipe's length can only be (1) for now, but got "
+                f"({len_vector_datapipe}) instead. Consider merging your vector data "
+                f"into a single `geopandas.GeoSeries` or `geopandas.GeoDataFrame`, "
+                f"e.g. using `geodataframe0.append(geodataframe2)`."
+            )
+
+    def __iter__(self) -> Iterator:
+        it = iter(self.source_datapipe)
+        geodataframe = next(it)
+
+        for raster in self.mask_datapipe:
+            mask = raster.rio.bounds()
+            clipped_geodataframe = geodataframe.clip(mask=mask, **self.kwargs)
+
+            yield clipped_geodataframe, raster
+
+    def __len__(self) -> int:
+        return len(self.mask_datapipe)

--- a/zen3geo/tests/test_datapipes_geopandas.py
+++ b/zen3geo/tests/test_datapipes_geopandas.py
@@ -1,0 +1,102 @@
+"""
+Tests for geopandas datapipes.
+"""
+import numpy as np
+import pytest
+import xarray as xr
+from torchdata.datapipes.iter import IterableWrapper
+
+from zen3geo.datapipes import GeoPandasRectangleClipper
+
+gpd = pytest.importorskip("geopandas")
+shapely = pytest.importorskip("shapely")
+
+# %%
+@pytest.fixture(scope="module", name="geodataframe")
+def fixture_geodataframe():
+    """
+    A geopandas.GeoDataFrame containing a collection of shapely.geometry
+    objects to use in the tests.
+    """
+    geometries: list = [
+        shapely.geometry.box(minx=0.0, miny=0.0, maxx=2.0, maxy=2.0),
+        shapely.geometry.box(minx=2.0, miny=2.0, maxx=4.0, maxy=4.0),
+    ]
+    geodataframe = gpd.GeoDataFrame(data={"geometry": geometries})
+    geodataframe = geodataframe.set_crs(crs="OGC:CRS84")
+
+    return geodataframe
+
+
+@pytest.fixture(scope="function", name="dataset")
+def fixture_dataset():
+    """
+    The sample xarray.Dataset to use in the tests.
+    """
+    dataarray = xr.DataArray(
+        data=np.ones(shape=(1, 5, 7)),
+        coords=dict(
+            band=[0],
+            y=np.linspace(start=4.0, stop=0.0, num=5),
+            x=np.linspace(start=-1.0, stop=5, num=7),
+        ),
+        dims=("band", "y", "x"),
+        name="foo",
+    )
+    dataset: xr.Dataset = dataarray.to_dataset()
+    dataset: xr.Dataset = dataset.rio.write_crs(input_crs="OGC:CRS84")
+
+    return dataset
+
+
+# %%
+def test_geopandas_rectangle_clipper_geoseries_dataset(geodataframe, dataset):
+    """
+    Ensure that GeoPandasRectangleClipper works to clip a geopandas.GeoSeries
+    vector with an xarray.Dataset raster and outputs a tuple made up of a
+    spatially subsetted geopandas.GeoSeries and the xarray.Dataset raster mask.
+    """
+    dp_vector = IterableWrapper(iterable=[geodataframe.geometry])
+    dp_raster = IterableWrapper(
+        iterable=[
+            dataset.rio.clip_box(minx=-1, miny=0, maxx=1, maxy=1),
+            dataset.rio.clip_box(minx=3, miny=3, maxx=5, maxy=4),
+        ]
+    )
+
+    # Using class constructors
+    dp_clipped = GeoPandasRectangleClipper(
+        source_datapipe=dp_vector, mask_datapipe=dp_raster
+    )
+    # Using functional form (recommended)
+    dp_clipped = dp_vector.clip_vector_with_rectangle(mask_datapipe=dp_raster)
+
+    assert len(dp_clipped) == 2
+    it = iter(dp_clipped)
+
+    clipped_geoseries, raster_chip = next(it)
+    assert clipped_geoseries.crs == "OGC:CRS84"
+    assert all(clipped_geoseries.geom_type == "Polygon")
+    assert clipped_geoseries.shape == (1,)
+    assert clipped_geoseries[0].bounds == (0.0, 0.0, 1.5, 1.5)
+    assert raster_chip.dims == {"band": 1, "y": 2, "x": 3}
+    assert raster_chip.rio.bounds() == (-1.5, -0.5, 1.5, 1.5)
+
+    clipped_geoseries, raster_chip = next(it)
+    assert clipped_geoseries.shape == (1,)
+    assert clipped_geoseries[1].bounds == (2.5, 2.5, 4.0, 4.0)
+    assert raster_chip.dims == {"band": 1, "y": 2, "x": 3}
+    assert raster_chip.rio.bounds() == (2.5, 2.5, 5.5, 4.5)
+    assert raster_chip.rio.crs == "OGC:CRS84"
+
+
+def test_geopandas_rectangle_clipper_incorrect_length(geodataframe, dataset):
+    """
+    Ensure that GeoPandasRectangleClipper raises a NotImplementedError when the
+    length of the vector datapipe is not equal to 1.
+    """
+    dp_vector = IterableWrapper(iterable=[geodataframe, geodataframe])
+    dp_raster = IterableWrapper(iterable=[dataset, dataset, dataset])
+
+    with pytest.raises(NotImplementedError, match="The vector datapipe's length can"):
+        dp_clipped = dp_vector.clip_vector_with_rectangle(mask_datapipe=dp_raster)


### PR DESCRIPTION
An iterable-style DataPipe for clipping vector geometries with the rectangular bounding box extent of raster grids!

**Preview** at https://zen3geo--52.org.readthedocs.build/en/52/api.html#zen3geo.datapipes.GeoPandasRectangleClipper

Needed for #49

TODO:
- [x] Initial implementation
- [x] Add unit tests
- [x] On-the-fly reproject vector CRS to raster CRS if they don't match

Possible extensions in future PRs
- [ ] Refactor on-the-fly reproject logic to be more efficient by reprojecting only a subset of the geometries
- [ ] Allow rectangular clipping with a 4-element list as in https://geopandas.org/en/v0.11.0/docs/reference/api/geopandas.clip.html