### PR TITLE
:speech_balloon: Edit type hints, isort imports and quick docstring fixes

### DIFF
--- a/docs/chipping.md
+++ b/docs/chipping.md
@@ -230,7 +230,7 @@ def xr_collate_fn(samples) -> torch.Tensor:
 ```
 
 Then, pass this collate function to
-{py:class}`torchdata.datapipes.iter.Collator`.
+{py:class}`torchdata.datapipes.iter.Collator` (functional name: `collate`).
 
 ```{code-cell}
 dp_collate = dp_batch.collate(collate_fn=xr_collate_fn)

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -188,7 +188,7 @@ def fn(da):
     return torch.as_tensor(da.data)
 ```
 
-Using {py:class}`torchdata.datapipes.iter.Mapper`,
+Using {py:class}`torchdata.datapipes.iter.Mapper` (functional name: `map`),
 we'll apply the tensor conversion function to each dataarray in the DataPipe.
 
 ```{code-cell}

--- a/zen3geo/datapipes/datashader.py
+++ b/zen3geo/datapipes/datashader.py
@@ -10,12 +10,12 @@ except ImportError:
 try:
     import spatialpandas
     from spatialpandas.geometry import (
-        PointDtype,
-        MultiPointDtype,
         LineDtype,
         MultiLineDtype,
-        PolygonDtype,
+        MultiPointDtype,
         MultiPolygonDtype,
+        PointDtype,
+        PolygonDtype,
     )
 except ImportError:
     spatialpandas = None
@@ -43,8 +43,8 @@ class DatashaderRasterizerIterDataPipe(IterDataPipe):
 
     vector_datapipe : IterDataPipe[geopandas.GeoDataFrame]
         A DataPipe that contains :py:class:`geopandas.GeoSeries` or
-        :py:class:`geopandas.GeoDataFrame` vector geometries with a ``.crs``
-        attribute.
+        :py:class:`geopandas.GeoDataFrame` vector geometries with a
+        :py:attr:`.crs <geopandas.GeoDataFrame.crs>` property.
 
     agg : Optional[datashader.reductions.Reduction]
         Reduction operation to compute. Default depends on the input vector

--- a/zen3geo/datapipes/geopandas.py
+++ b/zen3geo/datapipes/geopandas.py
@@ -1,7 +1,7 @@
 """
 DataPipes for :doc:`geopandas <geopandas:index>`.
 """
-from typing import Any, Dict, Iterator, Optional
+from typing import Any, Dict, Iterator, Optional, Union
 
 try:
     import geopandas as gpd
@@ -134,7 +134,7 @@ class GeoPandasRectangleClipperIterDataPipe(IterDataPipe):
     def __init__(
         self,
         source_datapipe: IterDataPipe,
-        mask_datapipe: IterDataPipe[xr.DataArray],
+        mask_datapipe: IterDataPipe[Union[xr.DataArray, xr.Dataset]],
         **kwargs: Optional[Dict[str, Any]],
     ) -> None:
         if gpd is None:

--- a/zen3geo/datapipes/pyogrio.py
+++ b/zen3geo/datapipes/pyogrio.py
@@ -17,8 +17,8 @@ class PyogrioReaderIterDataPipe(IterDataPipe[StreamWrapper]):
     """
     Takes vector files (e.g. FlatGeoBuf, GeoPackage, GeoJSON) from local disk
     or URLs (as long as they can be read by pyogrio) and yields
-    :py:class:`geopandas.GeoDataFrame` objects
-    (functional name: ``read_from_pyogrio``).
+    :py:class:`geopandas.GeoDataFrame` objects (functional name:
+    ``read_from_pyogrio``).
 
     Based on
     https://github.com/pytorch/data/blob/v0.4.0/torchdata/datapipes/iter/load/iopath.py#L42-L97

--- a/zen3geo/tests/test_datapipes_pyogrio.py
+++ b/zen3geo/tests/test_datapipes_pyogrio.py
@@ -11,8 +11,8 @@ pyogrio = pytest.importorskip("pyogrio")
 # %%
 def test_pyogrio_reader():
     """
-    Ensure that PyogrioReader works to read in a GeoTIFF file and outputs a
-    tuple made up of a filename and an xarray.DataArray object.
+    Ensure that PyogrioReader works to read in a GeoTIFF file and outputs an
+    xarray.DataArray object.
     """
     file_url: str = "https://github.com/geopandas/pyogrio/raw/v0.4.0/pyogrio/tests/fixtures/test_gpkg_nulls.gpkg"
     dp = IterableWrapper(iterable=[file_url])

--- a/zen3geo/tests/test_datapipes_pyogrio.py
+++ b/zen3geo/tests/test_datapipes_pyogrio.py
@@ -11,8 +11,8 @@ pyogrio = pytest.importorskip("pyogrio")
 # %%
 def test_pyogrio_reader():
     """
-    Ensure that PyogrioReader works to read in a GeoTIFF file and outputs an
-    xarray.DataArray object.
+    Ensure that PyogrioReader works to read in a GeoPackage file and outputs a
+    geopandas.GeoDataFrame object.
     """
     file_url: str = "https://github.com/geopandas/pyogrio/raw/v0.4.0/pyogrio/tests/fixtures/test_gpkg_nulls.gpkg"
     dp = IterableWrapper(iterable=[file_url])


### PR DESCRIPTION
Just a random collection of mostly documentation-related patches.

Patches type-hints in #52, isort imports in #35, mention functional name of IterDataPipe in walkthroughs #8 and #20, and remove mention of returned tuple to patch #33.