### PR TITLE
:memo: Add install from conda-forge instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,8 @@ Or the stable version from [PyPI](https://pypi.org/project/zen3geo):
 
     pip install zen3geo
 
-More detailed instructions at https://zen3geo.readthedocs.io/en/latest/#installation
+If instead, [conda-forge](https://anaconda.org/conda-forge/zen3geo) you desire:
+
+    mamba install --channel conda-forge zen3geo
+
+Other instructions, see https://zen3geo.readthedocs.io/en/latest/#installation

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,12 +11,17 @@ Get what you need, not more, not less:
 | `pip install zen3geo[spatial]` | rioxarray, torchdata, datashader, spatialpandas |
 | `pip install zen3geo[vector]`  | rioxarray, torchdata, pyogrio[geopandas] |
 
-Retrieve more 'extras' using
+Retrieve more ['extras'](https://github.com/weiji14/zen3geo/blob/main/pyproject.toml) using
 
     pip install zen3geo[raster,spatial,vector]
 
 To install the development version from [TestPyPI](https://test.pypi.org/project/zen3geo), do:
 
     pip install --pre --extra-index-url https://test.pypi.org/simple/ zen3geo
+
+May [conda-forge](https://anaconda.org/conda-forge/zen3geo) be with you,
+though optional dependencies it has not.
+
+    mamba install --channel conda-forge zen3geo
 
 For the eager ones, {ref}`contributing <contributing:running:locally>` will take you further.


### PR DESCRIPTION
Get zen3geo via mamba from https://anaconda.org/conda-forge/zen3geo! Feedstock repo is at https://github.com/conda-forge/zen3geo-feedstock.

**Preview** at https://zen3geo--55.org.readthedocs.build/en/55/#installation