### PR TITLE
:package: Exclude tests from source distribution and binary wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
 ]
+exclude = ["zen3geo/tests"]
 
 [tool.poetry.dependencies]
 # Required


### PR DESCRIPTION
Keeping things lightweight by reducing the sdist size from 17.7kB to 14.0kB, and also the bdist wheel package from about 25.0kB to 18.2kB. There are still doctests in the source code though!

See zen3geo v0.4.1.dev1 file sizes at https://test.pypi.org/project/zen3geo/0.4.1.dev1/#files

References:
- https://python-poetry.org/docs/pyproject/#include-and-exclude
- https://discuss.python.org/t/should-sdists-include-docs-and-tests/14578