### PR TITLE
:sparkles: PySTACAPISearchIterDataPipe to query dynamic STAC Catalogs

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -59,6 +59,9 @@ sphinx:
       pystac:
         - 'https://pystac.readthedocs.io/en/latest/'
         - null
+      pystac_client:
+        - 'https://pystac-client.readthedocs.io/en/latest/'
+        - null
       python:
         - 'https://docs.python.org/3/'
         - null

--- a/docs/api.md
+++ b/docs/api.md
@@ -45,6 +45,15 @@
     :show-inheritance:
 ```
 
+### PySTAC Client
+
+```{eval-rst}
+.. automodule:: zen3geo.datapipes.pystac_client
+.. autoclass:: zen3geo.datapipes.PySTACAPISearch
+.. autoclass:: zen3geo.datapipes.pystac_client.PySTACAPISearchIterDataPipe
+    :show-inheritance:
+```
+
 ### Rioxarray
 
 ```{eval-rst}

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,11 +9,12 @@ Get what you need, not more, not less:
 | `pip install zen3geo`          | rioxarray, torchdata |
 | `pip install zen3geo[raster]`  | rioxarray, torchdata, xbatcher |
 | `pip install zen3geo[spatial]` | rioxarray, torchdata, datashader, spatialpandas |
+| `pip install zen3geo[stac]`    | rioxarray, torchdata, pystac, pystac-client |
 | `pip install zen3geo[vector]`  | rioxarray, torchdata, pyogrio[geopandas] |
 
 Retrieve more ['extras'](https://github.com/weiji14/zen3geo/blob/main/pyproject.toml) using
 
-    pip install zen3geo[raster,spatial,vector]
+    pip install zen3geo[raster,spatial,stac,vector]
 
 To install the development version from [TestPyPI](https://test.pypi.org/project/zen3geo), do:
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -3028,13 +3028,14 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [extras]
 docs = ["adlfs", "contextily", "datashader", "graphviz", "jupyter-book", "matplotlib", "planetary-computer", "pyogrio", "pystac", "spatialpandas", "xbatcher"]
 raster = ["xbatcher"]
-spatial = ["datashader", "pystac", "pystac-client", "spatialpandas"]
+spatial = ["datashader", "spatialpandas"]
+stac = ["pystac", "pystac-client"]
 vector = ["pyogrio"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8, <3.12"
-content-hash = "0adafb59178301ac166b0b488b7db2f1799252fcef681cca7ad47d9fd2de37ba"
+content-hash = "ae212704d211197f6701436fc0127e9024775ec50de69bf639e282d81f56d316"
 
 [metadata.files]
 adal = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -2094,7 +2094,7 @@ validation = ["jsonschema (>=3.0)"]
 
 [[package]]
 name = "pystac-client"
-version = "0.3.5"
+version = "0.4.0"
 description = "Python library for working with Spatiotemporal Asset Catalog (STAC)."
 category = "main"
 optional = true
@@ -2106,7 +2106,7 @@ python-dateutil = ">=2.7.0"
 requests = ">=2.25"
 
 [package.extras]
-validation = ["jsonschema (==3.2.0)"]
+validation = ["jsonschema (>=4.5.1)"]
 
 [[package]]
 name = "pytest"
@@ -3028,13 +3028,13 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [extras]
 docs = ["adlfs", "contextily", "datashader", "graphviz", "jupyter-book", "matplotlib", "planetary-computer", "pyogrio", "pystac", "spatialpandas", "xbatcher"]
 raster = ["xbatcher"]
-spatial = ["datashader", "pystac", "spatialpandas"]
+spatial = ["datashader", "pystac", "pystac-client", "spatialpandas"]
 vector = ["pyogrio"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8, <3.12"
-content-hash = "b744418325d07994b7c83d3ee468fddea0996e18a27a5222ac09c275e69f9130"
+content-hash = "0adafb59178301ac166b0b488b7db2f1799252fcef681cca7ad47d9fd2de37ba"
 
 [metadata.files]
 adal = [
@@ -4574,8 +4574,8 @@ pystac = [
     {file = "pystac-1.4.0.tar.gz", hash = "sha256:6ec43e1c6bec50fbfbdede49c3ccb83ecd112072a938001b5c9c581fc2945e83"},
 ]
 pystac-client = [
-    {file = "pystac-client-0.3.5.tar.gz", hash = "sha256:42b64c7322096c53cc13b9ef77025edf5d718b9e872a101712649a4ae8d5e0d0"},
-    {file = "pystac_client-0.3.5-py3-none-any.whl", hash = "sha256:8a8dc068933c222cabc56801b8c21cdb1ae31e06544ea83ca92973c76b4f547b"},
+    {file = "pystac-client-0.4.0.tar.gz", hash = "sha256:8e014f669a88d55c7902a9c1a839048ee87939576060b2d3cc9f6d17cf879056"},
+    {file = "pystac_client-0.4.0-py3-none-any.whl", hash = "sha256:3c88c9f0473b29cec463ed9fd7b963f3c428efbea678a3804978b38dc9745ed0"},
 ]
 pytest = [
     {file = "pytest-7.1.2-py3-none-any.whl", hash = "sha256:13d0e3ccfc2b6e26be000cb6568c832ba67ba32e719443bfe725814d3c42433c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,9 +58,11 @@ docs = [
 raster = ["xbatcher"]
 spatial = [
     "datashader",
-    "pystac",
-    "pystac_client",
     "spatialpandas"
+]
+stac = [
+    "pystac",
+    "pystac_client"
 ]
 vector = ["pyogrio"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ jupyter-book = {version="*", optional=true}
 matplotlib = {version = "*", optional = true}
 planetary-computer = {version="*", optional=true}
 pystac = {version="*", optional=true}
+pystac-client = {version = "*", optional = true}
 
 [tool.poetry.group.dev.dependencies]
 black = "*"
@@ -58,6 +59,7 @@ raster = ["xbatcher"]
 spatial = [
     "datashader",
     "pystac",
+    "pystac_client",
     "spatialpandas"
 ]
 vector = ["pyogrio"]

--- a/zen3geo/datapipes/__init__.py
+++ b/zen3geo/datapipes/__init__.py
@@ -11,5 +11,8 @@ from zen3geo.datapipes.geopandas import (
 )
 from zen3geo.datapipes.pyogrio import PyogrioReaderIterDataPipe as PyogrioReader
 from zen3geo.datapipes.pystac import PySTACItemReaderIterDataPipe as PySTACItemReader
+from zen3geo.datapipes.pystac_client import (
+    PySTACAPISearchIterDataPipe as PySTACAPISearch,
+)
 from zen3geo.datapipes.rioxarray import RioXarrayReaderIterDataPipe as RioXarrayReader
 from zen3geo.datapipes.xbatcher import XbatcherSlicerIterDataPipe as XbatcherSlicer

--- a/zen3geo/datapipes/pystac_client.py
+++ b/zen3geo/datapipes/pystac_client.py
@@ -1,0 +1,117 @@
+"""
+DataPipes for :doc:`pystac-client <pystac_client:index>`.
+"""
+from typing import Any, Dict, Iterator, Optional
+
+try:
+    import pystac_client
+except ImportError:
+    pystac_client = None
+from torchdata.datapipes import functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe
+
+
+@functional_datapipe("search_for_pystac_item")
+class PySTACAPISearchIterDataPipe(IterDataPipe):
+    """
+    Takes dictionaries containing a STAC API query (as long as the parameters
+    are understood by :py:meth:`pystac_client.Client.search`) and yields
+    :py:class:`pystac_client.ItemSearch` objects (functional name:
+    ``search_for_pystac_item``).
+
+    Parameters
+    ----------
+    source_datapipe : IterDataPipe[dict]
+        A DataPipe that contains STAC API query parameters in the form of a
+        Python dictionary to pass to :py:meth:`pystac_client.Client.search`.
+        The arguments for each query parameter in the iterable can be unique.
+
+    catalog_url : str
+        The URL of a STAC Catalog. If not specified, this will use the
+        ``STAC_URL`` environment variable.
+
+    kwargs : Optional
+        Extra keyword arguments to pass to
+        :py:meth:`pystac_client.Client.search`. These arguments will be used
+        for every STAC API query, so it is best to set common arguments here.
+
+    Yields
+    ------
+    item_search : pystac_client.ItemSearch
+        A :py:class:`pystac_client.ItemSearch` object instance that represents
+        a deferred query to a STAC search endpoint as described in the
+        `STAC API - Item Search spec <https://github.com/radiantearth/stac-api-spec/tree/main/item-search>`_.
+
+    Raises
+    ------
+    ModuleNotFoundError
+        If ``pystac_client`` is not installed. See
+        :doc:`install instructions for pystac-client <pystac_client:index>`,
+        (e.g. via ``pip install pystac-client``) before using this class.
+
+    Example
+    -------
+    >>> import pytest
+    >>> pystac_client = pytest.importorskip("pystac_client")
+    ...
+    >>> from torchdata.datapipes.iter import IterableWrapper
+    >>> from zen3geo.datapipes import PySTACAPISearch
+    ...
+    >>> # Peform STAC API query using DataPipe
+    >>> query = dict(
+    ...     bbox=[174.5, -41.37, 174.9, -41.19],
+    ...     datetime=["2012-02-20T00:00:00Z", "2022-12-22T00:00:00Z"],
+    ... )
+    >>> dp = IterableWrapper(iterable=[query])
+    >>> dp_pystac_client = dp.search_for_pystac_item(
+    ...     catalog_url="https://planetarycomputer.microsoft.com/api/stac/v1",
+    ...     collections=["cop-dem-glo-30"],
+    ... )
+    >>> # Loop or iterate over the DataPipe stream
+    >>> it = iter(dp_pystac_client)
+    >>> stac_item_search = next(it)
+    >>> stac_items = list(stac_item_search.items())
+    >>> stac_items
+    [<Item id=Copernicus_DSM_COG_10_S42_00_E174_00_DEM>]
+    >>> stac_items[0].properties  # doctest: +NORMALIZE_WHITESPACE
+    {'gsd': 30,
+     'datetime': '2021-04-22T00:00:00Z',
+     'platform': 'TanDEM-X',
+     'proj:epsg': 4326,
+     'proj:shape': [3600, 3600],
+     'proj:transform': [0.0002777777777777778,
+      0.0,
+      173.9998611111111,
+      0.0,
+      -0.0002777777777777778,
+      -40.99986111111111]}
+    """
+
+    def __init__(
+        self,
+        source_datapipe: IterDataPipe[dict],
+        catalog_url: str,
+        **kwargs: Optional[Dict[str, Any]]
+    ) -> None:
+        if pystac_client is None:
+            raise ModuleNotFoundError(
+                "Package `pystac_client` is required to be installed to use this datapipe. "
+                "Please use `pip install pystac-client` or "
+                "`conda install -c conda-forge pystac-client` "
+                "to install the package"
+            )
+        self.source_datapipe: IterDataPipe[dict] = source_datapipe
+        self.catalog_url: str = catalog_url
+        self.kwargs = kwargs
+
+    def __iter__(self) -> Iterator:
+        catalog = pystac_client.Client.open(url=self.catalog_url)
+
+        for query in self.source_datapipe:
+            search = catalog.search(**query, **self.kwargs)
+            yield search
+            for item in search.items():
+                print(item)
+
+    def __len__(self) -> int:
+        return len(self.source_datapipe)

--- a/zen3geo/datapipes/pystac_client.py
+++ b/zen3geo/datapipes/pystac_client.py
@@ -110,8 +110,6 @@ class PySTACAPISearchIterDataPipe(IterDataPipe):
         for query in self.source_datapipe:
             search = catalog.search(**query, **self.kwargs)
             yield search
-            for item in search.items():
-                print(item)
 
     def __len__(self) -> int:
         return len(self.source_datapipe)

--- a/zen3geo/tests/test_datapipes_pystac_client.py
+++ b/zen3geo/tests/test_datapipes_pystac_client.py
@@ -1,0 +1,59 @@
+"""
+Tests for pystac-client datapipes.
+"""
+import pytest
+from torchdata.datapipes.iter import IterableWrapper
+
+from zen3geo.datapipes import PySTACAPISearch
+
+pystac_client = pytest.importorskip("pystac_client")
+
+# %%
+def test_pystac_client_item_search():
+    """
+    Ensure that PySTACAPISearch works to query a STAC API /search/ endpoint and
+    outputs a pystac_client.ItemSearch object.
+    """
+    query: dict = dict(
+        bbox=[150.9, -34.36, 151.3, -33.46],
+        datetime=["2000-01-01T00:00:00Z", "2020-12-31T00:00:00Z"],
+    )
+    dp = IterableWrapper(iterable=[query])
+
+    # Using class constructors
+    dp_pystac_client = PySTACAPISearch(
+        source_datapipe=dp,
+        catalog_url="https://explorer.sandbox.dea.ga.gov.au/stac/",
+        collections=["nidem"],
+    )
+    # Using functional form (recommended)
+    dp_pystac_client = dp.search_for_pystac_item(
+        catalog_url="https://explorer.sandbox.dea.ga.gov.au/stac/",
+        collections=["nidem"],
+    )
+
+    assert len(dp_pystac_client) == 1
+    it = iter(dp_pystac_client)
+    stac_item_search = next(it)
+    assert stac_item_search.client.title == "AWS Explorer"
+    assert stac_item_search.matched() == 2
+
+    stac_items = list(stac_item_search.items())
+    stac_item = stac_items[0]
+
+    assert stac_item.bbox == [
+        149.965907628116,
+        -35.199398016548095,
+        152.10531016837078,
+        -32.972806586656844,
+    ]
+    assert stac_item.datetime.isoformat() == "2001-07-02T00:00:00+00:00"
+    assert stac_item.geometry["type"] == "Polygon"
+    assert stac_item.properties == {
+        "title": "NIDEM_104_151.29_-34.22",
+        "created": "2018-10-15T10:00:00Z",
+        "proj:epsg": 4326,
+        "datetime": "2001-07-02T00:00:00Z",
+        "cubedash:region_code": None,
+    }
+    assert stac_item.assets["nidem"].extra_fields["eo:bands"] == [{"name": "nidem"}]

--- a/zen3geo/tests/test_datapipes_pystac_client.py
+++ b/zen3geo/tests/test_datapipes_pystac_client.py
@@ -55,3 +55,36 @@ def test_pystac_client_item_search():
         "cubedash:region_code": None,
     }
     assert stac_item.assets["nidem"].extra_fields["eo:bands"] == [{"name": "nidem"}]
+
+
+def test_pystac_client_item_search_open_parameters():
+    """
+    Ensure that PySTACAPISearch works to query a STAC API /search/ endpoint
+    with parameters passed to pystac_client.Client.open.
+    """
+    query: dict = dict(
+        bbox=[150.9, -34.36, 151.3, -33.46],
+        datetime=["2020-01-01T00:00:00Z", "2022-12-31T00:00:00Z"],
+    )
+    dp = IterableWrapper(iterable=[query])
+
+    # Using class constructors
+    dp_pystac_client = PySTACAPISearch(
+        source_datapipe=dp,
+        catalog_url="https://api.radiant.earth/mlhub/v1/",
+        parameters={"key": "ANON_MLHUB_API_KEY"},
+    )
+    # Using functional form (recommended)
+    dp_pystac_client = dp.search_for_pystac_item(
+        catalog_url="https://api.radiant.earth/mlhub/v1/",
+        parameters={"key": "ANON_MLHUB_API_KEY"},
+    )
+
+    assert len(dp_pystac_client) == 1
+    it = iter(dp_pystac_client)
+    stac_item_search = next(it)
+    assert stac_item_search.client.title == "Radiant MLHub API"
+    assert stac_item_search.client.description == "stac-fastapi"
+    assert stac_item_search.client.validate() == [
+        "https://schemas.stacspec.org/v1.0.0/catalog-spec/json-schema/catalog.json"
+    ]

--- a/zen3geo/tests/test_datapipes_pystac_client.py
+++ b/zen3geo/tests/test_datapipes_pystac_client.py
@@ -85,6 +85,3 @@ def test_pystac_client_item_search_open_parameters():
     stac_item_search = next(it)
     assert stac_item_search.client.title == "Radiant MLHub API"
     assert stac_item_search.client.description == "stac-fastapi"
-    assert stac_item_search.client.validate() == [
-        "https://schemas.stacspec.org/v1.0.0/catalog-spec/json-schema/catalog.json"
-    ]

--- a/zen3geo/tests/test_datapipes_pystac_client.py
+++ b/zen3geo/tests/test_datapipes_pystac_client.py
@@ -17,19 +17,17 @@ def test_pystac_client_item_search():
     query: dict = dict(
         bbox=[150.9, -34.36, 151.3, -33.46],
         datetime=["2000-01-01T00:00:00Z", "2020-12-31T00:00:00Z"],
+        collections=["nidem"],
     )
     dp = IterableWrapper(iterable=[query])
 
     # Using class constructors
     dp_pystac_client = PySTACAPISearch(
-        source_datapipe=dp,
-        catalog_url="https://explorer.sandbox.dea.ga.gov.au/stac/",
-        collections=["nidem"],
+        source_datapipe=dp, catalog_url="https://explorer.sandbox.dea.ga.gov.au/stac/"
     )
     # Using functional form (recommended)
     dp_pystac_client = dp.search_for_pystac_item(
-        catalog_url="https://explorer.sandbox.dea.ga.gov.au/stac/",
-        collections=["nidem"],
+        catalog_url="https://explorer.sandbox.dea.ga.gov.au/stac/"
     )
 
     assert len(dp_pystac_client) == 1


### PR DESCRIPTION
An iterable-style DataPipe to make [STAC API](https://github.com/radiantearth/stac-api-spec) queries to dynamic STAC Catalogs! Uses [pystac-client](https://github.com/stac-utils/pystac-client) to perform the [STAC API Item Search](https://github.com/radiantearth/stac-api-spec/tree/main/item-search) on the `/search` endpoint.

**Preview** at https://zen3geo--59.org.readthedocs.build/en/59/api.html#zen3geo.datapipes.PySTACAPISearch

Usage (requires `planetary-computer>=0.4.7` and `pystac-client>=0.5.0`):

```python
import planetary_computer
from torchdata.datapipes.iter import IterableWrapper
from zen3geo.datapipes import PySTACAPISearch

# Peform STAC API query using DataPipe
query = dict(
    bbox=[174.5, -41.37, 174.9, -41.19],
    datetime=["2012-02-20T00:00:00Z", "2022-12-22T00:00:00Z"],
    collections=["cop-dem-glo-30"],
)
dp = IterableWrapper(iterable=[query])
dp_pystac_client = dp.search_for_pystac_item(
    catalog_url="https://planetarycomputer.microsoft.com/api/stac/v1",
    modifier=planetary_computer.sign_inplace,
)
# Loop or iterate over the DataPipe stream
it = iter(dp_pystac_client)
stac_item_search = next(it)
stac_items = list(stac_item_search.items())

print(stac_items)
# [<Item id=Copernicus_DSM_COG_10_S42_00_E174_00_DEM>]

print(stac_items[0].properties)
# {'gsd': 30,
#  'datetime': '2021-04-22T00:00:00Z',
#  'platform': 'TanDEM-X',
#  'proj:epsg': 4326,
#  'proj:shape': [3600, 3600],
#  'proj:transform': [0.0002777777777777778,
#   0.0,
#   173.9998611111111,
#   0.0,
#   -0.0002777777777777778,
#   -40.99986111111111]}
```

TODO:
- [x] Initial implementation with a doctest
- [x] Add unit tests
- [x] Handle other parameters passed to [`pystac_client.Client.open`](https://pystac-client.readthedocs.io/en/v0.5.0/api.html#pystac_client.Client.open)
- [x] Add unit test to ensure parameters to [`pystac_client.Client.open`](https://pystac-client.readthedocs.io/en/v0.5.0/api.html#pystac_client.Client.open) works
- [x] Just list `pystac-client` as a dependency and not both `pystac` and `pystac-client`?
- ~Ensure that `STAC_URL` environment variable works~ (actually no, because `STAC_URL` no longer works, see https://github.com/stac-utils/pystac-client/pull/81, patch update at https://github.com/stac-utils/pystac-client/pull/317)

Part of https://github.com/weiji14/zen3geo/discussions/48.

References:
- https://stacindex.org/catalogs?access=public&type=api
- https://github.com/microsoft/torchgeo/pull/412#issuecomment-1235731321