### PR TITLE
:sparkles: StackSTACStackerIterDataPipe for stacking STAC items

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -33,7 +33,7 @@ jobs:
         include:
           - os: 'ubuntu-22.04'
             python-version: '3.10'
-            extra-packages: '--extras "raster spatial vector"'
+            extra-packages: '--extras "raster spatial stac vector"'
 
     steps:
       # Checkout current git repository

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -54,7 +54,7 @@ sphinx:
         - 'https://mmdetection.readthedocs.io/zh_CN/latest/'
         - null
       numpy:
-        - 'https://numpy.org/doc/stable'
+        - 'https://numpy.org/doc/stable/'
         - null
       pyogrio:
         - 'https://pyogrio.readthedocs.io/en/latest/'
@@ -75,10 +75,10 @@ sphinx:
         - 'https://corteva.github.io/rioxarray/stable/'
         - null
       shapely:
-        - 'https://shapely.readthedocs.io/en/latest'
+        - 'https://shapely.readthedocs.io/en/latest/'
         - null
       stackstac:
-        - 'https://stackstac.readthedocs.io/en/latest'
+        - 'https://stackstac.readthedocs.io/en/latest/'
         - null
       torch:
         - 'https://pytorch.org/docs/stable/'

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -41,6 +41,9 @@ sphinx:
       contextily:
         - 'https://contextily.readthedocs.io/en/latest/'
         - null
+      dask:
+        - 'https://docs.dask.org/en/latest/'
+        - null
       datashader:
         - 'https://datashader.org/'
         - null
@@ -73,6 +76,9 @@ sphinx:
         - null
       shapely:
         - 'https://shapely.readthedocs.io/en/latest'
+        - null
+      stackstac:
+        - 'https://stackstac.readthedocs.io/en/latest'
         - null
       torch:
         - 'https://pytorch.org/docs/stable/'

--- a/docs/api.md
+++ b/docs/api.md
@@ -63,6 +63,15 @@
     :show-inheritance:
 ```
 
+### Stackstac
+
+```{eval-rst}
+.. automodule:: zen3geo.datapipes.stackstac
+.. autoclass:: zen3geo.datapipes.StackSTACStacker
+.. autoclass:: zen3geo.datapipes.stackstac.StackSTACStackerIterDataPipe
+    :show-inheritance:
+```
+
 ### Xbatcher
 
 ```{eval-rst}

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ Get what you need, not more, not less:
 | `pip install zen3geo`          | rioxarray, torchdata |
 | `pip install zen3geo[raster]`  | rioxarray, torchdata, xbatcher |
 | `pip install zen3geo[spatial]` | rioxarray, torchdata, datashader, spatialpandas |
-| `pip install zen3geo[stac]`    | rioxarray, torchdata, pystac, pystac-client |
+| `pip install zen3geo[stac]`    | rioxarray, torchdata, pystac, pystac-client, stackstac |
 | `pip install zen3geo[vector]`  | rioxarray, torchdata, pyogrio[geopandas] |
 
 Retrieve more ['extras'](https://github.com/weiji14/zen3geo/blob/main/pyproject.toml) using

--- a/poetry.lock
+++ b/poetry.lock
@@ -484,7 +484,7 @@ cloudpickle = ">=1.1.1"
 distributed = {version = "2022.6.1", optional = true, markers = "extra == \"complete\""}
 fsspec = ">=0.6.0"
 jinja2 = {version = "*", optional = true, markers = "extra == \"complete\""}
-numpy = {version = ">=1.18", optional = true, markers = "extra == \"complete\""}
+numpy = {version = ">=1.18", optional = true, markers = "extra == \"array\""}
 packaging = ">=20.0"
 pandas = {version = ">=1.0", optional = true, markers = "extra == \"complete\""}
 partd = ">=0.3.10"
@@ -2767,6 +2767,23 @@ pure-eval = "*"
 tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
 
 [[package]]
+name = "stackstac"
+version = "0.4.3"
+description = "Load a STAC collection into xarray with dask"
+category = "main"
+optional = true
+python-versions = ">=3.8,<4.0"
+
+[package.dependencies]
+dask = {version = ">=2022.1.1", extras = ["array"]}
+pyproj = ">=3.0.0,<4.0.0"
+rasterio = ">=1.3.0,<2.0.0"
+xarray = ">=0.18"
+
+[package.extras]
+viz = ["Pillow (>=9.0.1,<10.0.0)", "aiohttp (>=3.7.4,<4.0.0)", "cachetools (>=4.2.2,<5.0.0)", "distributed (>=2022.1.1)", "ipyleaflet (>=0.13.6,<1.0.0)", "ipywidgets (>=7.6.3,<8.0.0)", "matplotlib (>=3.4.1)", "mercantile (>=1.1.6,<2.0.0)", "scipy (>=1.6.1,<2.0.0)"]
+
+[[package]]
 name = "tblib"
 version = "1.7.0"
 description = "Traceback serialization library."
@@ -3029,13 +3046,13 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 docs = ["adlfs", "contextily", "datashader", "graphviz", "jupyter-book", "matplotlib", "planetary-computer", "pyogrio", "pystac", "spatialpandas", "xbatcher"]
 raster = ["xbatcher"]
 spatial = ["datashader", "spatialpandas"]
-stac = ["pystac", "pystac-client"]
+stac = ["pystac", "pystac-client", "stackstac"]
 vector = ["pyogrio"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8, <3.12"
-content-hash = "ae212704d211197f6701436fc0127e9024775ec50de69bf639e282d81f56d316"
+content-hash = "37f5f1ade25c98838cac73546a42bc3f3b679fc72f6f9bea2b922747aaed1afb"
 
 [metadata.files]
 adal = [
@@ -5001,6 +5018,10 @@ sqlalchemy = [
 stack-data = [
     {file = "stack_data-0.2.0-py3-none-any.whl", hash = "sha256:999762f9c3132308789affa03e9271bbbe947bf78311851f4d485d8402ed858e"},
     {file = "stack_data-0.2.0.tar.gz", hash = "sha256:45692d41bd633a9503a5195552df22b583caf16f0b27c4e58c98d88c8b648e12"},
+]
+stackstac = [
+    {file = "stackstac-0.4.3-py3-none-any.whl", hash = "sha256:eea5aa1bb6d6575e65d48f5ae0650607408130bd3a601fbd5b1e6c2d028b77b4"},
+    {file = "stackstac-0.4.3.tar.gz", hash = "sha256:2a4137f590ab005e709078da199d666d2e357811abb8ea508c1e9d3b876cd76f"},
 ]
 tblib = [
     {file = "tblib-1.7.0-py2.py3-none-any.whl", hash = "sha256:289fa7359e580950e7d9743eab36b0691f0310fce64dee7d9c31065b8f723e23"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ matplotlib = {version = "*", optional = true}
 planetary-computer = {version="*", optional=true}
 pystac = {version="*", optional=true}
 pystac-client = {version = "*", optional = true}
+stackstac = {version = "*", optional = true}
 
 [tool.poetry.group.dev.dependencies]
 black = "*"
@@ -62,7 +63,8 @@ spatial = [
 ]
 stac = [
     "pystac",
-    "pystac_client"
+    "pystac_client",
+    "stackstac"
 ]
 vector = ["pyogrio"]
 

--- a/zen3geo/datapipes/__init__.py
+++ b/zen3geo/datapipes/__init__.py
@@ -15,4 +15,5 @@ from zen3geo.datapipes.pystac_client import (
     PySTACAPISearchIterDataPipe as PySTACAPISearch,
 )
 from zen3geo.datapipes.rioxarray import RioXarrayReaderIterDataPipe as RioXarrayReader
+from zen3geo.datapipes.stackstac import StackSTACStackerIterDataPipe as StackSTACStacker
 from zen3geo.datapipes.xbatcher import XbatcherSlicerIterDataPipe as XbatcherSlicer

--- a/zen3geo/datapipes/stackstac.py
+++ b/zen3geo/datapipes/stackstac.py
@@ -3,6 +3,8 @@ DataPipes for :doc:`stackstac <stackstac:index>`.
 """
 from typing import Any, Dict, Iterator, Optional
 
+import xarray as xr
+
 try:
     import stackstac
 except ImportError:
@@ -12,7 +14,7 @@ from torchdata.datapipes.iter import IterDataPipe
 
 
 @functional_datapipe("stack_stac_items")
-class StackSTACStackerIterDataPipe(IterDataPipe):
+class StackSTACStackerIterDataPipe(IterDataPipe[xr.DataArray]):
     """
     Takes :py:class:`pystac.Item` objects, reprojects them to the same grid
     and stacks them along time, to yield :py:class:`xarray.DataArray` objects
@@ -28,7 +30,7 @@ class StackSTACStackerIterDataPipe(IterDataPipe):
 
     Yields
     ------
-    stac_item : xarray.DataArray
+    datacube : xarray.DataArray
         An :py:class:`xarray.DataArray` backed by a
         :py:class:`dask.array.Array` containing the time-series datacube. The
         dimensions will be ("time", "band", "y", "x").
@@ -87,7 +89,7 @@ class StackSTACStackerIterDataPipe(IterDataPipe):
         self.source_datapipe: IterDataPipe = source_datapipe
         self.kwargs = kwargs
 
-    def __iter__(self) -> Iterator:
+    def __iter__(self) -> Iterator[xr.DataArray]:
         for stac_items in self.source_datapipe:
             yield stackstac.stack(items=stac_items, **self.kwargs)
 

--- a/zen3geo/datapipes/stackstac.py
+++ b/zen3geo/datapipes/stackstac.py
@@ -1,0 +1,95 @@
+"""
+DataPipes for :doc:`stackstac <stackstac:index>`.
+"""
+from typing import Any, Dict, Iterator, Optional
+
+try:
+    import stackstac
+except ImportError:
+    stackstac = None
+from torchdata.datapipes import functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe
+
+
+@functional_datapipe("stack_stac_items")
+class StackSTACStackerIterDataPipe(IterDataPipe):
+    """
+    Takes :py:class:`pystac.Item` objects, reprojects them to the same grid
+    and stacks them along time, to yield :py:class:`xarray.DataArray` objects
+    (functional name: ``stack_stac_items``).
+
+    Parameters
+    ----------
+    source_datapipe : IterDataPipe[pystac.Item]
+        A DataPipe that contains :py:class:`pystac.Item` objects.
+
+    kwargs : Optional
+        Extra keyword arguments to pass to :py:func:`stackstac.stack`.
+
+    Yields
+    ------
+    stac_item : xarray.DataArray
+        An :py:class:`xarray.DataArray` backed by a
+        :py:class:`dask.array.Array` containing the time-series datacube. The
+        dimensions will be ("time", "band", "y", "x").
+
+    Raises
+    ------
+    ModuleNotFoundError
+        If ``stackstac`` is not installed. See
+        :doc:`install instructions for stackstac <stackstac:index>`, (e.g. via
+        ``pip install stackstac``) before using this class.
+
+    Example
+    -------
+    >>> import pytest
+    >>> pystac = pytest.importorskip("pystac")
+    >>> stacstac = pytest.importorskip("stackstac")
+    ...
+    >>> from torchdata.datapipes.iter import IterableWrapper
+    >>> from zen3geo.datapipes import StackSTACStacker
+    ...
+    >>> # Stack different bands in a STAC Item using DataPipe
+    >>> item_url: str = "https://planetarycomputer.microsoft.com/api/stac/v1/collections/sentinel-1-grd/items/S1A_IW_GRDH_1SDV_20220914T093226_20220914T093252_044999_056053"
+    >>> stac_item = pystac.Item.from_file(href=item_url)
+    >>> dp = IterableWrapper(iterable=[stac_item])
+    >>> dp_stackstac = dp.stack_stac_items(
+    ...     assets=["vh", "vv"], epsg=32652, resolution=10
+    ... )
+    ...
+    >>> # Loop or iterate over the DataPipe stream
+    >>> it = iter(dp_stackstac)
+    >>> dataarray = next(it)
+    >>> print(dataarray.sizes)
+    Frozen({'time': 1, 'band': 2, 'y': 20686, 'x': 28043})
+    >>> print(dataarray.coords)
+    Coordinates:
+      * time                                   (time) datetime64[ns] 2022-09-14T0...
+        id                                     (time) <U62 'S1A_IW_GRDH_1SDV_2022...
+      * band                                   (band) <U2 'vh' 'vv'
+      * x                                      (x) float64 1.354e+05 ... 4.158e+05
+      * y                                      (y) float64 4.305e+06 ... 4.098e+06
+    ...
+    >>> print(dataarray.attrs["spec"])
+    RasterSpec(epsg=32652, bounds=(135370, 4098080, 415800, 4304940), resolutions_xy=(10, 10))
+    """
+
+    def __init__(
+        self, source_datapipe: IterDataPipe, **kwargs: Optional[Dict[str, Any]]
+    ) -> None:
+        if stackstac is None:
+            raise ModuleNotFoundError(
+                "Package `stackstac` is required to be installed to use this datapipe. "
+                "Please use `pip install stackstac` or "
+                "`conda install -c conda-forge stackstac` "
+                "to install the package"
+            )
+        self.source_datapipe: IterDataPipe = source_datapipe
+        self.kwargs = kwargs
+
+    def __iter__(self) -> Iterator:
+        for stac_items in self.source_datapipe:
+            yield stackstac.stack(items=stac_items, **self.kwargs)
+
+    def __len__(self) -> int:
+        return len(self.source_datapipe)

--- a/zen3geo/tests/test_datapipes_stackstac.py
+++ b/zen3geo/tests/test_datapipes_stackstac.py
@@ -1,0 +1,35 @@
+"""
+Tests for stackstac datapipes.
+"""
+import pytest
+from torchdata.datapipes.iter import IterableWrapper
+
+from zen3geo.datapipes import StackSTACStacker
+
+pystac = pytest.importorskip("pystac")
+stackstac = pytest.importorskip("stackstac")
+
+# %%
+def test_stackstac_stacker():
+    """
+    Ensure that StackSTACStacker works to stack multiple bands within a STAC
+    item and outputs an xarray.DataArray object.
+    """
+    item_url: str = "https://github.com/stac-utils/pystac/raw/v1.6.1/tests/data-files/raster/raster-sentinel2-example.json"
+    stac_item = pystac.Item.from_file(href=item_url)
+    dp = IterableWrapper(iterable=[stac_item])
+
+    # Using class constructors
+    dp_stackstac = StackSTACStacker(source_datapipe=dp, assets=["B02", "B03", "B04"])
+    # Using functional form (recommended)
+    dp_stackstac = dp.stack_stac_items(assets=["B02", "B03", "B04"])
+
+    assert len(dp_stackstac) == 1
+    it = iter(dp_stackstac)
+    dataarray = next(it)
+
+    assert dataarray.shape == (1, 3, 10980, 10980)
+    assert dataarray.dims == ("time", "band", "y", "x")
+    assert dataarray.rio.bounds() == (399955.0, 4090205.0, 509755.0, 4200005.0)
+    assert dataarray.rio.resolution() == (10.0, -10.0)
+    assert dataarray.rio.crs == "EPSG:32633"


### PR DESCRIPTION
An iterable-style DataPipe to stack [STAC items](https://pystac.readthedocs.io/en/1.0/api/pystac.html#pystac.Item)! Uses [stackstac](https://stackstac.readthedocs.io/en/v0.4.3/index.html) to do the reprojection and stacking along time.

**Preview** at https://zen3geo--61.org.readthedocs.build/en/61/api.html#zen3geo.datapipes.StackSTACStacker

Usage:

```python
import pystac
import stackstac

from torchdata.datapipes.iter import IterableWrapper
from zen3geo.datapipes import StackSTACStacker

# Stack different bands in a STAC Item using DataPipe
item_url: str = "https://planetarycomputer.microsoft.com/api/stac/v1/collections/sentinel-1-grd/items/S1A_IW_GRDH_1SDV_20220914T093226_20220914T093252_044999_056053"
stac_item = pystac.Item.from_file(href=item_url)
dp = IterableWrapper(iterable=[stac_item])
dp_stackstac = dp.stack_stac_items(assets=["vh", "vv"], epsg=32652, resolution=10)

# Loop or iterate over the DataPipe stream
it = iter(dp_stackstac)
dataarray = next(it)
print(dataarray.sizes)
# Frozen({'time': 1, 'band': 2, 'y': 20686, 'x': 28043})

print(dataarray.coords)
# Coordinates:
#   * time                                   (time) datetime64[ns] 2022-09-14T0...
#     id                                     (time) <U62 'S1A_IW_GRDH_1SDV_2022...
#   * band                                   (band) <U2 'vh' 'vv'
#   * x                                      (x) float64 1.354e+05 ... 4.158e+05
#   * y                                      (y) float64 4.305e+06 ... 4.098e+06
# ...

print(dataarray.attrs["spec"])
# RasterSpec(epsg=32652, bounds=(135370, 4098080, 415800, 4304940), resolutions_xy=(10, 10))
```

TODO:
- [x] Initial implementation with a doctest
- [x] Add unit test
- [ ] Handle different values of epsg (TODO in a follow-up PR)

Consider handling different values of `resolution`/`bounds`/`bounds_latlon` in the future. Limitation is that [torchdata.datapipes.iter.ZipperLongest](https://pytorch.org/data/0.4/generated/torchdata.datapipes.iter.ZipperLongest.html)'s `fill_value` only allows for one `fill_value` for all IterDataPipes, rather than individual `fill_value`s for each IterDataPipe as is needed here. OR, have a parametrized IterDataPipe that holds a dictionary instead of a single variable?

Part of #48

References:
- https://stackstac.readthedocs.io/en/v0.4.3/basic.html
- https://github.com/microsoft/torchgeo/pull/412#issuecomment-1235842635