### PR TITLE
:children_crossing: Walkthrough on stacking time-series earth observation data

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -13,6 +13,8 @@ chapters:
         file: vector-segmentation-masks
       - title: 🥡 Object Detection Boxes
         file: object-detection-boxes
+      - title: 🏳️‍🌈 Stacking layers
+        file: stacking
   - title: 📖 API Reference
     file: api
   - title: 📆 Changelog

--- a/docs/stacking.md
+++ b/docs/stacking.md
@@ -160,7 +160,7 @@ dp_copdem30_items
 
 This query yields the following DEM tile 🀫.
 
-![Copernicus 30m DEM over ](https://planetarycomputer.microsoft.com/api/data/v1/item/preview.png?collection=cop-dem-glo-30&item=Copernicus_DSM_COG_10_N00_00_E099_00_DEM&assets=data&colormap_name=terrain&rescale=-1000%2C4000)
+![Copernicus 30m DEM over Sumatra Barat, Indonesia](https://planetarycomputer.microsoft.com/api/data/v1/item/preview.png?collection=cop-dem-glo-30&item=Copernicus_DSM_COG_10_N00_00_E099_00_DEM&assets=data&colormap_name=terrain&rescale=-1000%2C4000)
 
 
 ## 1️⃣ Stack bands, append variables 📚
@@ -172,19 +172,19 @@ all of the items into 4D time-series tensor using
 `stack_stac_items`)!
 
 ```{code-cell}
-dp_stackstac = dp_stac_items.stack_stac_items(
+dp_sen1_stack = dp_sen1_items.stack_stac_items(
     assets=["vh", "vv"],  # SAR polarizations
     epsg=32647,  # UTM Zone 47N
     resolution=10,  # Spatial resolution of 10 metres
 )
-dp_stackstac
+dp_sen1_stack
 ```
 
 The result is a single {py:class}`xarray.DataArray` 'datacube' 🧊 with
 dimensions (time, band, y, x).
 
 ```{code-cell}
-it = iter(dp_stackstac)
+it = iter(dp_sen1_stack)
 dataarray = next(it)
 dataarray
 ```

--- a/docs/stacking.md
+++ b/docs/stacking.md
@@ -1,0 +1,128 @@
+---
+jupytext:
+  formats: md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+---
+
+# Stacking layers
+
+> Do not see them differently
+>
+> Do not consider all as the same
+>
+> Unwaveringly, practice guarding the One
+
+In Geographic Information Systems 🌐, geographic data is arranged as different
+'layers' 🍰. For example:
+
+- Multispectral or hyperspectral 🌈 optical satellites collect different
+  radiometric **bands** from slices along the electromagnetic spectrum
+- Synthetic Aperture Radar (SAR) 📡 sensors have different **polarizations**
+  such as HH, HV, VH & VV
+- Satellite laser and radar altimeters 🛰️ measure **elevation** which can be
+  turned into a Digital Elevation Model (DEM)
+
+As long as these layers are georeferenced 📍 though, they can be stacked! This
+tutorial will cover the following topics:
+
+- Searching for spatiotemporal datasets in a
+  [dynamic STAC Catalog](https://stacspec.org/en/about/stac-spec) 📚
+- Stacking time-series 📆 data into a 4D tensor of shape (time, channel, y, x)
+- Organizing different geographic 🗺️ layers into a dataset suitable for change
+  detection
+
+
+## 🎉 **Getting started**
+
+Load up them libraries!
+
+```{code-cell}
+import planetary_computer
+import pystac
+import torchdata
+import zen3geo
+```
+
+## 0️⃣ Search for time-series geospatial data 📅
+
+This time, we'll be looking at change detection using time-series data. The
+focus area is [Gunung Talamau](https://ban.wikipedia.org/wiki/Gunung_Talamau),
+Sumatra Barat, Indonesia 🇮🇩 where an
+[earthquake on 25 Feb 2022](https://id.wikipedia.org/wiki/Gempa_bumi_Pasaman_Barat_2022)
+triggered a series of landslides ⛰️. Affected areas will be mapped using
+Sentinel-1 Ground-Range Detected (GRD) SAR data 📡 obtained via a
+spatiotemporal query to a [STAC](https://stacspec.org) API.
+
+🔗 Links:
+- https://unosat.org/services
+- [UNOSAT satellite-detected landslide maps](https://unosat.org/products/3064)
+- [Microsoft Planetary Computer STAC Explorer](https://planetarycomputer.microsoft.com/explore?c=99.9822%2C0.0563&z=11.34&v=2&d=sentinel-1-grd&m=cql%3Ac3f87a557aa4e237d4820f413f9d33d8&r=VV%2C+VH+False-color+composite&s=false%3A%3A100%3A%3Atrue&ae=0)
+
+
+To start, let’s define an 🧭 area of interest and 📆 time range.
+
+```{code-cell}
+# Spatiotemporal query on STAC catalog for Sentinel-1 SAR data
+query = dict(
+    bbox=[99.8, -0.24, 100.07, -0.15],  # West, South, North, East
+    datetime=["2022-01-04T00:00:00Z", "2022-04-24T23:59:59Z"],
+    collections=["sentinel-1-grd"],
+)
+dp = torchdata.datapipes.iter.IterableWrapper(iterable=[query])
+```
+
+Then, search over a dynamic STAC Catalog 📚 for items matching the
+spatiotemporal query ❔ using
+{py:class}`zen3geo.datapipes.PySTACAPISearch` (functional name:
+`search_for_pystac_item`).
+
+```{code-cell}
+dp_pystac_client = dp.search_for_pystac_item(
+    catalog_url="https://planetarycomputer.microsoft.com/api/stac/v1",
+    modifier=planetary_computer.sign_inplace,
+)
+```
+
+The output is a {py:class}`pystac_client.ItemSearch` 🔎 instance that only
+holds the STAC API query information ℹ️ but doesn't request for data! We'll
+need to order it to return something like a {py:class}`pystac.ItemCollection`.
+
+```{code-cell}
+def get_all_items(item_search) -> pystac.ItemCollection:
+    return item_search.item_collection()
+```
+
+```{code-cell}
+dp_stac_items = dp_pystac_client.map(fn=get_all_items)
+dp_stac_items
+```
+
+Each {py:class}`pystac.Item` in a {py:class}`pystac.ItemCollection` represents
+a 🛰️ Sentinel-1 GRD image captured at a particular datetime ⌚. Let's stack 🥞
+all of the items into 4D time-series tensor using
+{py:class}`zen3geo.datapipes.StackSTACStacker` (functional name:
+`stack_stac_items`)!
+
+```{code-cell}
+dp_stackstac = dp_stac_items.stack_stac_items(
+    assets=["vh", "vv"],  # SAR polarizations
+    epsg=32647,  # UTM Zone 47N
+    resolution=10,  # Spatial resolution of 10 metres
+)
+dp_stackstac
+```
+
+The result is a single {py:class}`xarray.DataArray` 'datacube' 🧊 with
+dimensions (time, band, y, x).
+
+```{code-cell}
+it = iter(dp_stackstac)
+dataarray = next(it)
+dataarray
+```

--- a/docs/stacking.md
+++ b/docs/stacking.md
@@ -43,6 +43,7 @@ tutorial will cover the following topics:
 Load up them libraries!
 
 ```{code-cell}
+import numpy as np
 import planetary_computer
 import pystac
 import torchdata
@@ -60,9 +61,9 @@ Sentinel-1 Ground-Range Detected (GRD) SAR data 📡 obtained via a
 spatiotemporal query to a [STAC](https://stacspec.org) API.
 
 🔗 Links:
-- https://unosat.org/services
-- [UNOSAT satellite-detected landslide maps](https://unosat.org/products/3064)
-- [Microsoft Planetary Computer STAC Explorer](https://planetarycomputer.microsoft.com/explore?c=99.9822%2C0.0563&z=11.34&v=2&d=sentinel-1-grd&m=cql%3Ac3f87a557aa4e237d4820f413f9d33d8&r=VV%2C+VH+False-color+composite&s=false%3A%3A100%3A%3Atrue&ae=0)
+- [UNOSAT satellite-detected landslide maps over Pasaman, Indonesia](https://unosat.org/products/3064)
+- [Humanitarian Data Exchange link](https://data.humdata.org/dataset/landslide-analysis-in-mount-talakmau-in-pasaman-pasaman-barat-districts-indonesia-as-of-04)
+- [Microsoft Planetary Computer STAC Explorer](https://planetarycomputer.microsoft.com/explore?c=99.9823%2C0.0564&z=11.34&v=2&d=sentinel-1-grd%7C%7Ccop-dem-glo-30&m=cql%3A99108f1228c2543e04cad62d0a795c1a%7C%7CMost+recent&r=VV%2C+VH+False-color+composite%7C%7CElevation+%28terrain%29&s=false%3A%3A100%3A%3Atrue%7C%7Ctrue%3A%3A100%3A%3Atrue&ae=0)
 
 This is how the Sentinel-1 radar image looks like over Sumatra Barat, Indonesia
 on 23 February 2022, two days before the earthquake.
@@ -162,23 +163,77 @@ This query yields the following DEM tile 🀫.
 
 ![Copernicus 30m DEM over Sumatra Barat, Indonesia](https://planetarycomputer.microsoft.com/api/data/v1/item/preview.png?collection=cop-dem-glo-30&item=Copernicus_DSM_COG_10_N00_00_E099_00_DEM&assets=data&colormap_name=terrain&rescale=-1000%2C4000)
 
+### Landslide extent vector polygons 🔶
+
+Now for the target labels 🏷️. Following {doc}`./vector-segmentation-masks`,
+we'll first load the digitized landslide polygons from a vector file 📁 using
+{py:class}`zen3geo.datapipes.PyogrioReader` (functional name:
+``read_from_pyogrio``).
+
+```{code-cell}
+# https://gdal.org/user/virtual_file_systems.html#vsizip-zip-archives
+shape_url = "/vsizip/vsicurl/https://unosat-maps.web.cern.ch/ID/LS20220308IDN/LS20220308IDN_SHP.zip/LS20220308IDN_SHP/S2_20220304_LandslideExtent_MountTalakmau.shp"
+
+dp_shapes = torchdata.datapipes.iter.IterableWrapper(iterable=[shape_url])
+dp_pyogrio = dp_shapes.read_from_pyogrio()
+dp_pyogrio
+```
+
+Let's take a look at the {py:class}`geopandas.GeoDataFrame` data table
+📊 to see the attributes inside.
+
+```{code-cell}
+it = iter(dp_pyogrio)
+geodataframe = next(it)
+print(geodataframe.bounds)
+geodataframe.dropna(axis="columns")
+```
+
+We'll show you what the landslide segmentation masks 😷 look like after it's
+been rasterized later 😉.
+
 
 ## 1️⃣ Stack bands, append variables 📚
 
+There are now three layers 🍰 to handle, two rasters and a vector. This section
+will show you step by step 📶 instructions to
+{doc}`combine them using xarray <xarray:user-guide/combining>` like so:
+
+1. Stack the Sentinel-1 🛰️ time-series STAC Items (GeoTIFFs) into an
+   {py:class}`xarray.DataArray`.
+2. Combine the Sentinel-1 and Copernicus DEM ⛰️ {py:class}`xarray.DataArray`
+   layers into a single {py:class}`xarray.Dataset`.
+3. Using the {py:class}`xarray.Dataset` as a canvas template, rasterize the
+   landslide 🛝 polygon extents, and append the resulting segmentation mask as
+   another data variable 🗃️ in the {py:class}`xarray.Dataset`.
+
+### Stack multi-channel time-series GeoTIFFs 🗓️
+
 Each {py:class}`pystac.Item` in a {py:class}`pystac.ItemCollection` represents
-a 🛰️ Sentinel-1 GRD image captured at a particular datetime ⌚. Let's stack 🥞
-all of the items into 4D time-series tensor using
-{py:class}`zen3geo.datapipes.StackSTACStacker` (functional name:
-`stack_stac_items`)!
+a 🛰️ Sentinel-1 GRD image captured at a particular datetime ⌚. Let's subset
+the data to just the mountain area, and stack 🥞 all the STAC items into a 4D
+time-series tensor using {py:class}`zen3geo.datapipes.StackSTACStacker`
+(functional name: `stack_stac_items`)!
 
 ```{code-cell}
 dp_sen1_stack = dp_sen1_items.stack_stac_items(
     assets=["vh", "vv"],  # SAR polarizations
     epsg=32647,  # UTM Zone 47N
-    resolution=10,  # Spatial resolution of 10 metres
+    resolution=30,  # Spatial resolution of 30 metres
+    bounds_latlon=[99.933681, -0.009951, 100.065765, 0.147054], # W, S, E, N
+    xy_coords="center",  # pixel centroid coords instead of topleft corner
+    dtype=np.float16,  # Use a lightweight data type
 )
 dp_sen1_stack
 ```
+
+The keyword arguments are passed to {py:func}`stackstac.stack` behind the
+scenes. The important parameters to set in this case are:
+
+- **assets**: The STAC item assets (typically the 'band' names)
+- **epsg**: The EPSG projection code, best if you know the native projection
+- **resolution**: Spatial resolution. The Sentinel-1 GRD is actually at 10m,
+  but we'll resample to 30m to keep things small and match the Copernicus DEM.
 
 The result is a single {py:class}`xarray.DataArray` 'datacube' 🧊 with
 dimensions (time, band, y, x).

--- a/poetry.lock
+++ b/poetry.lock
@@ -1773,7 +1773,7 @@ tests = ["check-manifest", "coverage", "defusedxml", "markdown2", "olefile", "pa
 
 [[package]]
 name = "planetary-computer"
-version = "0.4.6"
+version = "0.4.7"
 description = "Planetary Computer SDK for Python"
 category = "main"
 optional = true
@@ -2094,7 +2094,7 @@ validation = ["jsonschema (>=3.0)"]
 
 [[package]]
 name = "pystac-client"
-version = "0.4.0"
+version = "0.5.0"
 description = "Python library for working with Spatiotemporal Asset Catalog (STAC)."
 category = "main"
 optional = true
@@ -2103,7 +2103,7 @@ python-versions = ">=3.7"
 [package.dependencies]
 pystac = ">=1.4.0"
 python-dateutil = ">=2.7.0"
-requests = ">=2.25"
+requests = ">=2.27.1"
 
 [package.extras]
 validation = ["jsonschema (>=4.5.1)"]
@@ -4323,8 +4323,8 @@ pillow = [
     {file = "Pillow-9.2.0.tar.gz", hash = "sha256:75e636fd3e0fb872693f23ccb8a5ff2cd578801251f3a4f6854c6a5d437d3c04"},
 ]
 planetary-computer = [
-    {file = "planetary-computer-0.4.6.tar.gz", hash = "sha256:1bfec27c6fd50ede4b5e36a781ebaa9827ca4114dbfc6840220594147c24e4fb"},
-    {file = "planetary_computer-0.4.6-py3-none-any.whl", hash = "sha256:e09bf84724e80d46ea5fdd64eec75425b8ec002509c904cfe43c49c4e0869c2a"},
+    {file = "planetary-computer-0.4.7.tar.gz", hash = "sha256:fcac7bd119f3efc8e5f808d6ff014e0c3aed2b4af9a9621604aebf0f867ab65c"},
+    {file = "planetary_computer-0.4.7-py3-none-any.whl", hash = "sha256:bfc674791f13404ad73f955fe942d2a964c0db3c12cabe2c37faeb94b9a71350"},
 ]
 platformdirs = [
     {file = "platformdirs-2.5.2-py3-none-any.whl", hash = "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788"},
@@ -4592,8 +4592,8 @@ pystac = [
     {file = "pystac-1.4.0.tar.gz", hash = "sha256:6ec43e1c6bec50fbfbdede49c3ccb83ecd112072a938001b5c9c581fc2945e83"},
 ]
 pystac-client = [
-    {file = "pystac-client-0.4.0.tar.gz", hash = "sha256:8e014f669a88d55c7902a9c1a839048ee87939576060b2d3cc9f6d17cf879056"},
-    {file = "pystac_client-0.4.0-py3-none-any.whl", hash = "sha256:3c88c9f0473b29cec463ed9fd7b963f3c428efbea678a3804978b38dc9745ed0"},
+    {file = "pystac-client-0.5.0.tar.gz", hash = "sha256:cc45075c9fe6ae4c01db8099bf7ce70da9461d148c0dabe7e7e4a96ff2c82774"},
+    {file = "pystac_client-0.5.0-py3-none-any.whl", hash = "sha256:c4094222004ea369fd40a3c97bc85088bfea6c386d653678c673c4c2f6904155"},
 ]
 pytest = [
     {file = "pytest-7.1.2-py3-none-any.whl", hash = "sha256:13d0e3ccfc2b6e26be000cb6568c832ba67ba32e719443bfe725814d3c42433c"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -3043,7 +3043,7 @@ docs = ["jaraco.packaging (>=9)", "rst.linker (>=1.9)", "sphinx"]
 testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [extras]
-docs = ["adlfs", "contextily", "datashader", "graphviz", "jupyter-book", "matplotlib", "planetary-computer", "pyogrio", "pystac", "spatialpandas", "xbatcher"]
+docs = ["adlfs", "contextily", "datashader", "graphviz", "jupyter-book", "matplotlib", "planetary-computer", "pyogrio", "pystac", "pystac-client", "stackstac", "spatialpandas", "xbatcher"]
 raster = ["xbatcher"]
 spatial = ["datashader", "spatialpandas"]
 stac = ["pystac", "pystac-client", "stackstac"]
@@ -3052,7 +3052,7 @@ vector = ["pyogrio"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8, <3.12"
-content-hash = "37f5f1ade25c98838cac73546a42bc3f3b679fc72f6f9bea2b922747aaed1afb"
+content-hash = "44bf86fe0af1c417306ec4bad4bdb53666093fd794c33ea6fb4873a9ba240a9a"
 
 [metadata.files]
 adal = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,8 @@ docs = [
     "planetary-computer",
     "pyogrio",
     "pystac",
+    "pystac_client",
+    "stackstac",
     "spatialpandas",
     "xbatcher"
 ]


### PR DESCRIPTION
Tutorial on stacking a time-series of Synthetic Aperture Radar polarization channels + Copernicus DEM for a change detection task. Will be looking at landslides digitized by UNOSAT over Gunung Talamau, Indonesia after the 25 Feb 2022 Pasaman Barat earthquake.

**Preview** at https://zen3geo--62.org.readthedocs.build/en/62/stacking.html

[![Satellite detected landslide extents as of 4 March 2022 over Gunung Talamau, Indonesia](https://unosat.org/static/unosat_filesystem/3064/UNOSAT_A3_Natural_Landscape_LS20220308IDN_MountTalakmau_Indonesia_04Mar2022.jpg)](https://data.humdata.org/dataset/landslide-analysis-in-mount-talakmau-in-pasaman-pasaman-barat-districts-indonesia-as-of-04)

TODO:
- [x] Show how to do `pystac-client` spatiotemporal query and stack STAC items using `stackstac`
- [x] Add Copernicus DEM into the DataPipe
- [x] Add landslide segmentation masks (rasterized from vector)
- [x] Compile everything together and pass into a DataLoader

Part of #48. Xref https://github.com/microsoft/torchgeo/pull/412#discussion_r853369916.