### PR TITLE
:sparkles: StackSTACMosaicIterDataPipe to mosaic tiles into one piece

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -67,10 +67,10 @@
 
 ```{eval-rst}
 .. automodule:: zen3geo.datapipes.stackstac
-.. autoclass:: zen3geo.datapipes.StackSTACStacker
-.. autoclass:: zen3geo.datapipes.stackstac.StackSTACStackerIterDataPipe
 .. autoclass:: zen3geo.datapipes.StackSTACMosaic
 .. autoclass:: zen3geo.datapipes.stackstac.StackSTACMosaicIterDataPipe
+.. autoclass:: zen3geo.datapipes.StackSTACStacker
+.. autoclass:: zen3geo.datapipes.stackstac.StackSTACStackerIterDataPipe
     :show-inheritance:
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -69,6 +69,8 @@
 .. automodule:: zen3geo.datapipes.stackstac
 .. autoclass:: zen3geo.datapipes.StackSTACStacker
 .. autoclass:: zen3geo.datapipes.stackstac.StackSTACStackerIterDataPipe
+.. autoclass:: zen3geo.datapipes.StackSTACMosaic
+.. autoclass:: zen3geo.datapipes.stackstac.StackSTACMosaicIterDataPipe
     :show-inheritance:
 ```
 

--- a/zen3geo/datapipes/__init__.py
+++ b/zen3geo/datapipes/__init__.py
@@ -15,5 +15,8 @@ from zen3geo.datapipes.pystac_client import (
     PySTACAPISearchIterDataPipe as PySTACAPISearch,
 )
 from zen3geo.datapipes.rioxarray import RioXarrayReaderIterDataPipe as RioXarrayReader
-from zen3geo.datapipes.stackstac import StackSTACStackerIterDataPipe as StackSTACStacker
+from zen3geo.datapipes.stackstac import (
+    StackSTACStackerIterDataPipe as StackSTACStacker,
+    StackSTACMosaicIterDataPipe as StackSTACMosaic,
+)
 from zen3geo.datapipes.xbatcher import XbatcherSlicerIterDataPipe as XbatcherSlicer

--- a/zen3geo/datapipes/__init__.py
+++ b/zen3geo/datapipes/__init__.py
@@ -16,7 +16,7 @@ from zen3geo.datapipes.pystac_client import (
 )
 from zen3geo.datapipes.rioxarray import RioXarrayReaderIterDataPipe as RioXarrayReader
 from zen3geo.datapipes.stackstac import (
-    StackSTACStackerIterDataPipe as StackSTACStacker,
     StackSTACMosaicIterDataPipe as StackSTACMosaic,
+    StackSTACStackerIterDataPipe as StackSTACStacker,
 )
 from zen3geo.datapipes.xbatcher import XbatcherSlicerIterDataPipe as XbatcherSlicer

--- a/zen3geo/datapipes/stackstac.py
+++ b/zen3geo/datapipes/stackstac.py
@@ -13,90 +13,6 @@ from torchdata.datapipes import functional_datapipe
 from torchdata.datapipes.iter import IterDataPipe
 
 
-@functional_datapipe("stack_stac_items")
-class StackSTACStackerIterDataPipe(IterDataPipe[xr.DataArray]):
-    """
-    Takes :py:class:`pystac.Item` objects, reprojects them to the same grid
-    and stacks them along time, to yield :py:class:`xarray.DataArray` objects
-    (functional name: ``stack_stac_items``).
-
-    Parameters
-    ----------
-    source_datapipe : IterDataPipe[pystac.Item]
-        A DataPipe that contains :py:class:`pystac.Item` objects.
-
-    kwargs : Optional
-        Extra keyword arguments to pass to :py:func:`stackstac.stack`.
-
-    Yields
-    ------
-    datacube : xarray.DataArray
-        An :py:class:`xarray.DataArray` backed by a
-        :py:class:`dask.array.Array` containing the time-series datacube. The
-        dimensions will be ("time", "band", "y", "x").
-
-    Raises
-    ------
-    ModuleNotFoundError
-        If ``stackstac`` is not installed. See
-        :doc:`install instructions for stackstac <stackstac:index>`, (e.g. via
-        ``pip install stackstac``) before using this class.
-
-    Example
-    -------
-    >>> import pytest
-    >>> pystac = pytest.importorskip("pystac")
-    >>> stacstac = pytest.importorskip("stackstac")
-    ...
-    >>> from torchdata.datapipes.iter import IterableWrapper
-    >>> from zen3geo.datapipes import StackSTACStacker
-    ...
-    >>> # Stack different bands in a STAC Item using DataPipe
-    >>> item_url: str = "https://planetarycomputer.microsoft.com/api/stac/v1/collections/sentinel-1-grd/items/S1A_IW_GRDH_1SDV_20220914T093226_20220914T093252_044999_056053"
-    >>> stac_item = pystac.Item.from_file(href=item_url)
-    >>> dp = IterableWrapper(iterable=[stac_item])
-    >>> dp_stackstac = dp.stack_stac_items(
-    ...     assets=["vh", "vv"], epsg=32652, resolution=10
-    ... )
-    ...
-    >>> # Loop or iterate over the DataPipe stream
-    >>> it = iter(dp_stackstac)
-    >>> dataarray = next(it)
-    >>> print(dataarray.sizes)
-    Frozen({'time': 1, 'band': 2, 'y': 20686, 'x': 28043})
-    >>> print(dataarray.coords)
-    Coordinates:
-      * time                                   (time) datetime64[ns] 2022-09-14T0...
-        id                                     (time) <U62 'S1A_IW_GRDH_1SDV_2022...
-      * band                                   (band) <U2 'vh' 'vv'
-      * x                                      (x) float64 1.354e+05 ... 4.158e+05
-      * y                                      (y) float64 4.305e+06 ... 4.098e+06
-    ...
-    >>> print(dataarray.attrs["spec"])
-    RasterSpec(epsg=32652, bounds=(135370, 4098080, 415800, 4304940), resolutions_xy=(10, 10))
-    """
-
-    def __init__(
-        self, source_datapipe: IterDataPipe, **kwargs: Optional[Dict[str, Any]]
-    ) -> None:
-        if stackstac is None:
-            raise ModuleNotFoundError(
-                "Package `stackstac` is required to be installed to use this datapipe. "
-                "Please use `pip install stackstac` or "
-                "`conda install -c conda-forge stackstac` "
-                "to install the package"
-            )
-        self.source_datapipe: IterDataPipe = source_datapipe
-        self.kwargs = kwargs
-
-    def __iter__(self) -> Iterator[xr.DataArray]:
-        for stac_items in self.source_datapipe:
-            yield stackstac.stack(items=stac_items, **self.kwargs)
-
-    def __len__(self) -> int:
-        return len(self.source_datapipe)
-
-
 @functional_datapipe("mosaic_dataarray")
 class StackSTACMosaicIterDataPipe(IterDataPipe[xr.DataArray]):
     """
@@ -183,6 +99,90 @@ class StackSTACMosaicIterDataPipe(IterDataPipe[xr.DataArray]):
     def __iter__(self) -> Iterator[xr.DataArray]:
         for dataarray in self.source_datapipe:
             yield stackstac.mosaic(arr=dataarray, **self.kwargs)
+
+    def __len__(self) -> int:
+        return len(self.source_datapipe)
+
+
+@functional_datapipe("stack_stac_items")
+class StackSTACStackerIterDataPipe(IterDataPipe[xr.DataArray]):
+    """
+    Takes :py:class:`pystac.Item` objects, reprojects them to the same grid
+    and stacks them along time, to yield :py:class:`xarray.DataArray` objects
+    (functional name: ``stack_stac_items``).
+
+    Parameters
+    ----------
+    source_datapipe : IterDataPipe[pystac.Item]
+        A DataPipe that contains :py:class:`pystac.Item` objects.
+
+    kwargs : Optional
+        Extra keyword arguments to pass to :py:func:`stackstac.stack`.
+
+    Yields
+    ------
+    datacube : xarray.DataArray
+        An :py:class:`xarray.DataArray` backed by a
+        :py:class:`dask.array.Array` containing the time-series datacube. The
+        dimensions will be ("time", "band", "y", "x").
+
+    Raises
+    ------
+    ModuleNotFoundError
+        If ``stackstac`` is not installed. See
+        :doc:`install instructions for stackstac <stackstac:index>`, (e.g. via
+        ``pip install stackstac``) before using this class.
+
+    Example
+    -------
+    >>> import pytest
+    >>> pystac = pytest.importorskip("pystac")
+    >>> stacstac = pytest.importorskip("stackstac")
+    ...
+    >>> from torchdata.datapipes.iter import IterableWrapper
+    >>> from zen3geo.datapipes import StackSTACStacker
+    ...
+    >>> # Stack different bands in a STAC Item using DataPipe
+    >>> item_url: str = "https://planetarycomputer.microsoft.com/api/stac/v1/collections/sentinel-1-grd/items/S1A_IW_GRDH_1SDV_20220914T093226_20220914T093252_044999_056053"
+    >>> stac_item = pystac.Item.from_file(href=item_url)
+    >>> dp = IterableWrapper(iterable=[stac_item])
+    >>> dp_stackstac = dp.stack_stac_items(
+    ...     assets=["vh", "vv"], epsg=32652, resolution=10
+    ... )
+    ...
+    >>> # Loop or iterate over the DataPipe stream
+    >>> it = iter(dp_stackstac)
+    >>> dataarray = next(it)
+    >>> print(dataarray.sizes)
+    Frozen({'time': 1, 'band': 2, 'y': 20686, 'x': 28043})
+    >>> print(dataarray.coords)
+    Coordinates:
+      * time                                   (time) datetime64[ns] 2022-09-14T0...
+        id                                     (time) <U62 'S1A_IW_GRDH_1SDV_2022...
+      * band                                   (band) <U2 'vh' 'vv'
+      * x                                      (x) float64 1.354e+05 ... 4.158e+05
+      * y                                      (y) float64 4.305e+06 ... 4.098e+06
+    ...
+    >>> print(dataarray.attrs["spec"])
+    RasterSpec(epsg=32652, bounds=(135370, 4098080, 415800, 4304940), resolutions_xy=(10, 10))
+    """
+
+    def __init__(
+        self, source_datapipe: IterDataPipe, **kwargs: Optional[Dict[str, Any]]
+    ) -> None:
+        if stackstac is None:
+            raise ModuleNotFoundError(
+                "Package `stackstac` is required to be installed to use this datapipe. "
+                "Please use `pip install stackstac` or "
+                "`conda install -c conda-forge stackstac` "
+                "to install the package"
+            )
+        self.source_datapipe: IterDataPipe = source_datapipe
+        self.kwargs = kwargs
+
+    def __iter__(self) -> Iterator[xr.DataArray]:
+        for stac_items in self.source_datapipe:
+            yield stackstac.stack(items=stac_items, **self.kwargs)
 
     def __len__(self) -> int:
         return len(self.source_datapipe)

--- a/zen3geo/datapipes/stackstac.py
+++ b/zen3geo/datapipes/stackstac.py
@@ -59,9 +59,8 @@ class StackSTACMosaicIterDataPipe(IterDataPipe[xr.DataArray]):
     ... ]
     >>> stac_items = [pystac.Item.from_file(href=url) for url in item_urls]
     >>> dataarray = stackstac.stack(items=stac_items)
-    >>> print(dataarray.sizes)
-    Frozen({'time': 2, 'band': 1, 'y': 3600, 'x': 7200})
-    >>>
+    >>> assert dataarray.sizes == {'time': 2, 'band': 1, 'y': 3600, 'x': 7200}
+    ...
     >>> # Mosaic different tiles in an xarray.DataArray using DataPipe
     >>> dp = IterableWrapper(iterable=[dataarray])
     >>> dp_mosaic = dp.mosaic_dataarray()

--- a/zen3geo/datapipes/stackstac.py
+++ b/zen3geo/datapipes/stackstac.py
@@ -95,3 +95,94 @@ class StackSTACStackerIterDataPipe(IterDataPipe[xr.DataArray]):
 
     def __len__(self) -> int:
         return len(self.source_datapipe)
+
+
+@functional_datapipe("mosaic_dataarray")
+class StackSTACMosaicIterDataPipe(IterDataPipe[xr.DataArray]):
+    """
+    Takes :py:class:`xarray.DataArray` objects, flattens a dimension by picking
+    the first valid pixel, to yield mosaicked :py:class:`xarray.DataArray`
+    objects (functional name: ``mosaic_dataarray``).
+
+    Parameters
+    ----------
+    source_datapipe : IterDataPipe[xarray.DataArray]
+        A DataPipe that contains :py:class:`xarray.DataArray` objects, with
+        e.g. dimensions ("time", "band", "y", "x").
+
+    kwargs : Optional
+        Extra keyword arguments to pass to :py:func:`stackstac.mosaic`.
+
+    Yields
+    ------
+    dataarray : xarray.DataArray
+        An :py:class:`xarray.DataArray` that has been mosaicked with e.g.
+        dimensions ("band", "y", "x").
+
+    Raises
+    ------
+    ModuleNotFoundError
+        If ``stackstac`` is not installed. See
+        :doc:`install instructions for stackstac <stackstac:index>`, (e.g. via
+        ``pip install stackstac``) before using this class.
+
+    Example
+    -------
+    >>> import pytest
+    >>> import xarray as xr
+    >>> pystac = pytest.importorskip("pystac")
+    >>> stackstac = pytest.importorskip("stackstac")
+    ...
+    >>> from torchdata.datapipes.iter import IterableWrapper
+    >>> from zen3geo.datapipes import StackSTACMosaic
+    ...
+    >>> # Get list of ALOS DEM tiles to mosaic together later
+    >>> item_urls = [
+    ...     "https://planetarycomputer.microsoft.com/api/stac/v1/collections/alos-dem/items/ALPSMLC30_N022E113_DSM",
+    ...     "https://planetarycomputer.microsoft.com/api/stac/v1/collections/alos-dem/items/ALPSMLC30_N022E114_DSM",
+    ... ]
+    >>> stac_items = [pystac.Item.from_file(href=url) for url in item_urls]
+    >>> dataarray = stackstac.stack(items=stac_items)
+    >>> print(dataarray.sizes)
+    Frozen({'time': 2, 'band': 1, 'y': 3600, 'x': 7200})
+    >>>
+    >>> # Mosaic different tiles in an xarray.DataArray using DataPipe
+    >>> dp = IterableWrapper(iterable=[dataarray])
+    >>> dp_mosaic = dp.mosaic_dataarray()
+    ...
+    >>> # Loop or iterate over the DataPipe stream
+    >>> it = iter(dp_mosaic)
+    >>> dataarray = next(it)
+    >>> print(dataarray.sizes)
+    Frozen({'band': 1, 'y': 3600, 'x': 7200})
+    >>> print(dataarray.coords)
+    Coordinates:
+      * band         (band) <U4 'data'
+      * x            (x) float64 113.0 113.0 113.0 113.0 ... 115.0 115.0 115.0 115.0
+      * y            (y) float64 23.0 23.0 23.0 23.0 23.0 ... 22.0 22.0 22.0 22.0
+    ...
+    >>> print(dataarray.attrs["spec"])
+    RasterSpec(epsg=4326, bounds=(113.0, 22.0, 115.0, 23.0), resolutions_xy=(0.0002777777777777778, 0.0002777777777777778))
+    """
+
+    def __init__(
+        self,
+        source_datapipe: IterDataPipe[xr.DataArray],
+        **kwargs: Optional[Dict[str, Any]]
+    ) -> None:
+        if stackstac is None:
+            raise ModuleNotFoundError(
+                "Package `stackstac` is required to be installed to use this datapipe. "
+                "Please use `pip install stackstac` or "
+                "`conda install -c conda-forge stackstac` "
+                "to install the package"
+            )
+        self.source_datapipe: IterDataPipe = source_datapipe
+        self.kwargs = kwargs
+
+    def __iter__(self) -> Iterator[xr.DataArray]:
+        for dataarray in self.source_datapipe:
+            yield stackstac.mosaic(arr=dataarray, **self.kwargs)
+
+    def __len__(self) -> int:
+        return len(self.source_datapipe)

--- a/zen3geo/tests/test_datapipes_stackstac.py
+++ b/zen3geo/tests/test_datapipes_stackstac.py
@@ -1,7 +1,9 @@
 """
 Tests for stackstac datapipes.
 """
+import numpy as np
 import pytest
+import xarray as xr
 from torchdata.datapipes.iter import IterableWrapper
 
 from zen3geo.datapipes import StackSTACStacker
@@ -10,6 +12,19 @@ pystac = pytest.importorskip("pystac")
 stackstac = pytest.importorskip("stackstac")
 
 # %%
+def test_stackstac_mosaic():
+    """
+    Ensure that StackSTACMosaic works to mosaic tiles within a 4D
+    xarray.DataArray to a 3D xarray.DataArray.
+    """
+    datacube: xr.DataArray = xr.DataArray(
+        data=np.ones(shape=(3, 1, 32, 32)), dims=["tile", "band", "y", "x"]
+    )
+    dataarray = stackstac.mosaic(arr=datacube, dim="tile")
+    assert dataarray.sizes == {"band": 1, "y": 32, "x": 32}
+    assert dataarray.sum() == 1 * 32 * 32
+
+
 def test_stackstac_stacker():
     """
     Ensure that StackSTACStacker works to stack multiple bands within a STAC


### PR DESCRIPTION
An iterable-style DataPipe to mosaic tiles in an `xarray.DataArray`! Uses [`stackstac.mosaic`](https://stackstac.readthedocs.io/en/v0.4.3/api/main/stackstac.mosaic.html) to do the mosaic operation.

Preview at https://zen3geo--63.org.readthedocs.build/en/63/api.html#zen3geo.datapipes.StackSTACMosaic

Usage:

```python
import pystac

from torchdata.datapipes.iter import IterableWrapper
from zen3geo.datapipes import StackSTACMosaic, StackSTACStacker

# Get list of ALOS DEM tiles to mosaic together later
item_urls = [
    "https://planetarycomputer.microsoft.com/api/stac/v1/collections/alos-dem/items/ALPSMLC30_N022E113_DSM",
    "https://planetarycomputer.microsoft.com/api/stac/v1/collections/alos-dem/items/ALPSMLC30_N022E114_DSM",
]

stac_items = [pystac.Item.from_file(href=url) for url in item_urls]
dp = IterableWrapper(iterable=[stac_items])

# Mosaic different tiles in an xarray.DataArray using DataPipe
dp_mosaic = dp.stack_stac_items().mosaic_dataarray()

# Loop or iterate over the DataPipe stream
it = iter(dp_mosaic)
dataarray = next(it)

print(dataarray.sizes)
# Frozen({'band': 1, 'y': 3600, 'x': 7200})

print(dataarray.coords)
# Coordinates:
#   * band         (band) <U4 'data'
#   * x            (x) float64 113.0 113.0 113.0 113.0 ... 115.0 115.0 115.0 115.0
#   * y            (y) float64 23.0 23.0 23.0 23.0 23.0 ... 22.0 22.0 22.0 22.0
#     proj:epsg    int64 4326
#     instruments  <U5 'prism'
#     platform     <U4 'alos'
#     gsd          int64 30
#     proj:shape   object {3600}
#     epsg         int64 4326

print(dataarray.attrs["spec"])
# RasterSpec(epsg=4326, bounds=(113.0, 22.0, 115.0, 23.0), resolutions_xy=(0.0002777777777777778, 0.0002777777777777778))
```


TODO:
- [x] Initial implementation with a doctest
- [x] Add unit test

Needed for #62