### PR TITLE
:truck: Rename to PySTACAPISearcher and StackSTACMosaicker

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -90,7 +90,7 @@ sphinx:
         - 'https://pytorch.org/vision/main/'
         - null
       xarray:
-        - 'https://docs.xarray.dev/en/latest/'
+        - 'https://docs.xarray.dev/en/stable/'
         - null
       xbatcher:
         - 'https://xbatcher.readthedocs.io/en/latest/'

--- a/docs/api.md
+++ b/docs/api.md
@@ -67,8 +67,8 @@
 
 ```{eval-rst}
 .. automodule:: zen3geo.datapipes.stackstac
-.. autoclass:: zen3geo.datapipes.StackSTACMosaic
-.. autoclass:: zen3geo.datapipes.stackstac.StackSTACMosaicIterDataPipe
+.. autoclass:: zen3geo.datapipes.StackSTACMosaicker
+.. autoclass:: zen3geo.datapipes.stackstac.StackSTACMosaickerIterDataPipe
 .. autoclass:: zen3geo.datapipes.StackSTACStacker
 .. autoclass:: zen3geo.datapipes.stackstac.StackSTACStackerIterDataPipe
     :show-inheritance:

--- a/docs/api.md
+++ b/docs/api.md
@@ -49,8 +49,8 @@
 
 ```{eval-rst}
 .. automodule:: zen3geo.datapipes.pystac_client
-.. autoclass:: zen3geo.datapipes.PySTACAPISearch
-.. autoclass:: zen3geo.datapipes.pystac_client.PySTACAPISearchIterDataPipe
+.. autoclass:: zen3geo.datapipes.PySTACAPISearcher
+.. autoclass:: zen3geo.datapipes.pystac_client.PySTACAPISearcherIterDataPipe
     :show-inheritance:
 ```
 

--- a/zen3geo/datapipes/__init__.py
+++ b/zen3geo/datapipes/__init__.py
@@ -16,7 +16,7 @@ from zen3geo.datapipes.pystac_client import (
 )
 from zen3geo.datapipes.rioxarray import RioXarrayReaderIterDataPipe as RioXarrayReader
 from zen3geo.datapipes.stackstac import (
-    StackSTACMosaicIterDataPipe as StackSTACMosaic,
+    StackSTACMosaickerIterDataPipe as StackSTACMosaicker,
     StackSTACStackerIterDataPipe as StackSTACStacker,
 )
 from zen3geo.datapipes.xbatcher import XbatcherSlicerIterDataPipe as XbatcherSlicer

--- a/zen3geo/datapipes/__init__.py
+++ b/zen3geo/datapipes/__init__.py
@@ -12,7 +12,7 @@ from zen3geo.datapipes.geopandas import (
 from zen3geo.datapipes.pyogrio import PyogrioReaderIterDataPipe as PyogrioReader
 from zen3geo.datapipes.pystac import PySTACItemReaderIterDataPipe as PySTACItemReader
 from zen3geo.datapipes.pystac_client import (
-    PySTACAPISearchIterDataPipe as PySTACAPISearch,
+    PySTACAPISearcherIterDataPipe as PySTACAPISearcher,
 )
 from zen3geo.datapipes.rioxarray import RioXarrayReaderIterDataPipe as RioXarrayReader
 from zen3geo.datapipes.stackstac import (

--- a/zen3geo/datapipes/pystac_client.py
+++ b/zen3geo/datapipes/pystac_client.py
@@ -12,7 +12,7 @@ from torchdata.datapipes.iter import IterDataPipe
 
 
 @functional_datapipe("search_for_pystac_item")
-class PySTACAPISearchIterDataPipe(IterDataPipe):
+class PySTACAPISearcherIterDataPipe(IterDataPipe):
     """
     Takes dictionaries containing a STAC API query (as long as the parameters
     are understood by :py:meth:`pystac_client.Client.search`) and yields
@@ -75,7 +75,7 @@ class PySTACAPISearchIterDataPipe(IterDataPipe):
     >>> pystac_client = pytest.importorskip("pystac_client")
     ...
     >>> from torchdata.datapipes.iter import IterableWrapper
-    >>> from zen3geo.datapipes import PySTACAPISearch
+    >>> from zen3geo.datapipes import PySTACAPISearcher
     ...
     >>> # Peform STAC API query using DataPipe
     >>> query = dict(

--- a/zen3geo/datapipes/stackstac.py
+++ b/zen3geo/datapipes/stackstac.py
@@ -14,7 +14,7 @@ from torchdata.datapipes.iter import IterDataPipe
 
 
 @functional_datapipe("mosaic_dataarray")
-class StackSTACMosaicIterDataPipe(IterDataPipe[xr.DataArray]):
+class StackSTACMosaickerIterDataPipe(IterDataPipe[xr.DataArray]):
     """
     Takes :py:class:`xarray.DataArray` objects, flattens a dimension by picking
     the first valid pixel, to yield mosaicked :py:class:`xarray.DataArray`
@@ -50,7 +50,7 @@ class StackSTACMosaicIterDataPipe(IterDataPipe[xr.DataArray]):
     >>> stackstac = pytest.importorskip("stackstac")
     ...
     >>> from torchdata.datapipes.iter import IterableWrapper
-    >>> from zen3geo.datapipes import StackSTACMosaic
+    >>> from zen3geo.datapipes import StackSTACMosaicker
     ...
     >>> # Get list of ALOS DEM tiles to mosaic together later
     >>> item_urls = [

--- a/zen3geo/tests/test_datapipes_pystac_client.py
+++ b/zen3geo/tests/test_datapipes_pystac_client.py
@@ -4,15 +4,15 @@ Tests for pystac-client datapipes.
 import pytest
 from torchdata.datapipes.iter import IterableWrapper
 
-from zen3geo.datapipes import PySTACAPISearch
+from zen3geo.datapipes import PySTACAPISearcher
 
 pystac_client = pytest.importorskip("pystac_client")
 
 # %%
 def test_pystac_client_item_search():
     """
-    Ensure that PySTACAPISearch works to query a STAC API /search/ endpoint and
-    outputs a pystac_client.ItemSearch object.
+    Ensure that PySTACAPISearcher works to query a STAC API /search/ endpoint
+    and outputs a pystac_client.ItemSearch object.
     """
     query: dict = dict(
         bbox=[150.9, -34.36, 151.3, -33.46],
@@ -22,7 +22,7 @@ def test_pystac_client_item_search():
     dp = IterableWrapper(iterable=[query])
 
     # Using class constructors
-    dp_pystac_client = PySTACAPISearch(
+    dp_pystac_client = PySTACAPISearcher(
         source_datapipe=dp, catalog_url="https://explorer.sandbox.dea.ga.gov.au/stac/"
     )
     # Using functional form (recommended)
@@ -59,7 +59,7 @@ def test_pystac_client_item_search():
 
 def test_pystac_client_item_search_open_parameters():
     """
-    Ensure that PySTACAPISearch works to query a STAC API /search/ endpoint
+    Ensure that PySTACAPISearcher works to query a STAC API /search/ endpoint
     with parameters passed to pystac_client.Client.open.
     """
     query: dict = dict(
@@ -69,7 +69,7 @@ def test_pystac_client_item_search_open_parameters():
     dp = IterableWrapper(iterable=[query])
 
     # Using class constructors
-    dp_pystac_client = PySTACAPISearch(
+    dp_pystac_client = PySTACAPISearcher(
         source_datapipe=dp,
         catalog_url="https://api.radiant.earth/mlhub/v1/",
         parameters={"key": "ANON_MLHUB_API_KEY"},

--- a/zen3geo/tests/test_datapipes_stackstac.py
+++ b/zen3geo/tests/test_datapipes_stackstac.py
@@ -12,9 +12,9 @@ pystac = pytest.importorskip("pystac")
 stackstac = pytest.importorskip("stackstac")
 
 # %%
-def test_stackstac_mosaic():
+def test_stackstac_mosaicker():
     """
-    Ensure that StackSTACMosaic works to mosaic tiles within a 4D
+    Ensure that StackSTACMosaicker works to mosaic tiles within a 4D
     xarray.DataArray to a 3D xarray.DataArray.
     """
     datacube: xr.DataArray = xr.DataArray(


### PR DESCRIPTION
Follow torchdata's IterDataPipe naming convention at https://pytorch.org/data/0.4/tutorial.html#naming to add an 'er' to the end.

- Rename PySTACAPISearch to PySTACAPISearcher, patches #59
- Rename StackSTACMosaic to StackSTACMosaicker, patches #63

Not a breaking change as zen3geo v0.5.0 isn't released yet (phew).