### PR TITLE
:pushpin: Pin min pystac-client and stackstac to v0.4.0, pystac to 1.4.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3052,7 +3052,7 @@ vector = ["pyogrio"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8, <3.12"
-content-hash = "44bf86fe0af1c417306ec4bad4bdb53666093fd794c33ea6fb4873a9ba240a9a"
+content-hash = "3c168466d744bdc831ee1912aa75cd531857703fbf3dcbf06be551f93af42d0a"
 
 [metadata.files]
 adal = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,10 @@ torchdata = ">=0.4.0"
 # Optional
 datashader = {version = ">=0.14.0", optional = true}
 pyogrio = {version = ">=0.4.0", extras = ["geopandas"], optional = true}
+pystac = {version=">=1.4.0", optional=true}
+pystac-client = {version = ">=0.4.0", optional = true}
 spatialpandas = {version = ">=0.4.0", optional = true}
+stackstac = {version = ">=0.4.0", optional = true}
 xbatcher = {version = ">=0.1.0", optional = true}
 # Docs
 adlfs = {version = "*", optional = true}
@@ -34,9 +37,6 @@ graphviz = {version = "*", optional = true}
 jupyter-book = {version="*", optional=true}
 matplotlib = {version = "*", optional = true}
 planetary-computer = {version="*", optional=true}
-pystac = {version="*", optional=true}
-pystac-client = {version = "*", optional = true}
-stackstac = {version = "*", optional = true}
 
 [tool.poetry.group.dev.dependencies]
 black = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,12 @@ authors = ["Wei Ji <23487320+weiji14@users.noreply.github.com>"]
 license = "LGPL-3.0-or-later"
 readme = "README.md"
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
     "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: GIS",
+    "Topic :: Scientific/Engineering :: Image Processing",
     "Topic :: Software Development :: Libraries",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
Set minimum pin of STAC extras dependencies. These are roughly the versions that support STAC API Spec 1.0.0-rc.1, with some slight upward bias. Also update some [PyPI trove classifiers](url) for the upcoming zen3geo v0.5.0 (#65).

References:
- https://pystac-client.readthedocs.io/en/v0.5.0/index.html#stac-versions
- https://github.com/stac-utils/pystac/tree/v1.6.1#versions
- https://github.com/radiantearth/stac-spec/discussions/1184
