### PR TITLE
:recycle: Use xarray.merge with join="override" in collate functions

### DIFF
--- a/docs/vector-segmentation-masks.md
+++ b/docs/vector-segmentation-masks.md
@@ -88,7 +88,7 @@ geographic coordinates by default (OGC:CRS84). To make the pixels more equal ğŸ”
 area, we can project it to a ğŸŒ local projected coordinate system instead.
 
 ```{code-cell}
-def reproject_to_local_utm(dataarray: xr.DataArray, resolution: float=100.0) -> xr.DataArray:
+def reproject_to_local_utm(dataarray: xr.DataArray, resolution: float=80.0) -> xr.DataArray:
     """
     Reproject an xarray.DataArray grid from OGC:CRS84 to a local UTM coordinate
     reference system.
@@ -382,8 +382,10 @@ def xr_collate_fn(image_and_mask: tuple) -> xr.Dataset:
     """
     # Turn 2 xr.DataArray objects into 1 xr.Dataset with multiple data vars
     image, mask = image_and_mask
-    dataset: xr.Dataset = image.isel(band=0).to_dataset(name="image")
-    dataset["mask"] = mask
+    dataset: xr.Dataset = xr.merge(
+        objects=[image.isel(band=0).rename("image"), mask.rename("mask")],
+        join="override",
+    )
 
     # Clip dataset to bounding box extent of where labels are
     mask_extent: tuple = mask.where(cond=mask == 1, drop=True).rio.bounds()

--- a/docs/vector-segmentation-masks.md
+++ b/docs/vector-segmentation-masks.md
@@ -73,7 +73,8 @@ Malaysia on 15 Dec 2019.
 ### Load and reproject image data 🔄
 
 To keep things simple, we'll load just the VV channel into a DataPipe via
-{py:class}`zen3geo.datapipes.rioxarray.RioXarrayReaderIterDataPipe` 😀.
+{py:class}`zen3geo.datapipes.RioXarrayReader` (functional name:
+`read_from_rioxarray`) 😀.
 
 ```{code-cell}
 url = signed_item.assets["vv"].href
@@ -196,6 +197,7 @@ put it into a DataPipe called {py:class}`zen3geo.datapipes.PyogrioReader`
 ```{code-cell}
 dp_shapes = torchdata.datapipes.iter.IterableWrapper(iterable=[shape_url])
 dp_pyogrio = dp_shapes.read_from_pyogrio()
+dp_pyogrio
 ```
 
 This will take care of loading the shapefile into a
@@ -227,7 +229,7 @@ correspond to the zoomed in Sentinel-1 image plotted earlier above.
 gdf.plot(figsize=(11.5, 9))
 ```
 
-```{tip}  
+```{tip}
 Make sure to understand your raster and vector datasets well first! Open the
 files up in your favourite 🌐 Geographic Information System (GIS) tool, see how
 they actually look like spatially. Then you'll have a better idea to decide on
@@ -465,7 +467,7 @@ Pass the DataPipe into {py:class}`torch.utils.data.DataLoader` 🤾!
 dataloader = torch.utils.data.DataLoader(dataset=dp_map)
 for i, batch in enumerate(dataloader):
     image, mask = batch
-    print(f"Batch {i} - image: {image.shape}, mask:{mask.shape}")
+    print(f"Batch {i} - image: {image.shape}, mask: {mask.shape}")
 ```
 
 Now go train some flood water detection models 🌊🌊🌊


### PR DESCRIPTION
Refactoring the xarray collate functions to use `xr.merge` instead of the dictionary style way of appending data variables to an xarray.Dataset.

**Preview** at https://zen3geo--72.org.readthedocs.build/en/72/vector-segmentation-masks.html#stacking-the-raster-layers

This is a solution adapted from 7787f8ead65ac395ca1b09d52c5caf818fa10367 in #62 that is more robust to images being cut off due to rounding issues as with 6b18934a9b084d6fbb6f2c0f280101524aee3548 in #31.

Patches #62 and #31.