### PR TITLE
:pushpin: Pin minimum xbatcher version to 0.2.0

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,6 +16,10 @@ build:
       # Generate the Sphinx configuration for this Jupyter Book so it builds.
       # https://jupyterbook.org/en/stable/publish/readthedocs.html
       - "jupyter-book config sphinx docs/"
+    post_install:
+      # Install torchdata=0.4.1 instead of 0.5.0 to prevent AttributeError, see
+      # https://github.com/pytorch/data/issues/869
+      - "pip install torchdata==0.4.1"
 
 python:
   install:

--- a/docs/chipping.md
+++ b/docs/chipping.md
@@ -221,10 +221,7 @@ def xr_collate_fn(samples) -> torch.Tensor:
     and stacks them all into a single torch.Tensor.
     """
     tensors = [
-        torch.as_tensor(
-            data=sample.data_vars.get(key="__xarray_dataarray_variable__").data.astype("int16"),
-        )
-        for sample in samples
+        torch.as_tensor(data=sample.data.astype(dtype="int16")) for sample in samples
     ]
     return torch.stack(tensors=tensors)
 ```

--- a/docs/chipping.md
+++ b/docs/chipping.md
@@ -193,7 +193,7 @@ print(f"Number of items in first batch: {len(list(dp_batch)[0])}")
 ```
 
 Now each batch will have 10 chips of size 512 x 512, with
-each chip being an {py:class}``xarray.Dataset``.
+each chip being an {py:class}``xarray.DataArray``.
 
 ```{note}
 Notice how no mosaicking nor reprojection was done for the two satellite
@@ -212,13 +212,14 @@ Oh, and to be super clear, of the 3 batches of 10 chips each:
 Let's now stack all these chips into a single tensor per batch, with a
 (number, channel, height, width) shape like (10, 1, 512, 512). We'll need a
 custom 🪄 collate function to do the conversion
-(from {py:class}``xarray.Dataset`` to {py:class}``torch.Tensor``) and stacking.
+(from {py:class}``xarray.DataArray`` to {py:class}``torch.Tensor``) and
+stacking.
 
 ```{code-cell}
 def xr_collate_fn(samples) -> torch.Tensor:
     """
-    Converts individual xarray.Dataset objects to a torch.Tensor (int16 dtype),
-    and stacks them all into a single torch.Tensor.
+    Converts individual xarray.DataArray objects to a torch.Tensor (int16
+    dtype), and stacks them all into a single torch.Tensor.
     """
     tensors = [
         torch.as_tensor(data=sample.data.astype(dtype="int16")) for sample in samples

--- a/docs/object-detection-boxes.md
+++ b/docs/object-detection-boxes.md
@@ -248,7 +248,7 @@ And here's a side by side visualization of the 🌈 RGB chip image (left) and
 
 ```{code-cell}
 fig, ax = plt.subplots(ncols=2, figsize=(18, 9), sharex=True, sharey=True)
-raster.__xarray_dataarray_variable__.plot.imshow(ax=ax[0])
+raster.plot.imshow(ax=ax[0])
 vector.plot(ax=ax[1])
 ```
 
@@ -365,7 +365,7 @@ ibox
 
 ```{code-cell}
 fig, ax = plt.subplots(ncols=2, figsize=(18, 9), sharex=True, sharey=True)
-ax[0].imshow(X=ichip.__xarray_dataarray_variable__.transpose("y", "x", "band"))
+ax[0].imshow(X=ichip.transpose("y", "x", "band"))
 for i, row in ibox.iterrows():
     rectangle = matplotlib.patches.Rectangle(
         xy=(row.x1, row.y1),
@@ -429,12 +429,7 @@ def boximg_collate_fn(samples) -> (list[torch.Tensor], torch.Tensor, list[dict])
     ]
 
     tensors: list[torch.Tensor] = [
-        torch.as_tensor(
-            data=sample[1]
-            .data_vars.get(key="__xarray_dataarray_variable__")
-            .data.astype("int16"),
-        )
-        for sample in samples
+        torch.as_tensor(data=sample[1].data.astype(dtype="int16")) for sample in samples
     ]
     img_tensors = torch.stack(tensors=tensors)
 

--- a/docs/object-detection-boxes.md
+++ b/docs/object-detection-boxes.md
@@ -282,7 +282,7 @@ geographic bounds 🗺️ of each building footprint geometry 📐 in each 128x1
 chip.
 
 ```{code-cell}
-def polygon_to_bbox(geom_and_chip) -> (gpd.GeoDataFrame, xr.Dataset):
+def polygon_to_bbox(geom_and_chip) -> (gpd.GeoDataFrame, xr.DataArray):
     """
     Get bounding box (minx, miny, maxx, maxy) coordinates for each geometry in
     a geopandas.GeoDataFrame.
@@ -313,7 +313,7 @@ be flipped 🤸 upside down, and we'll be using the spatial bounds (or corner
 coordinates) of the 128x128 image chip as a reference 📍.
 
 ```{code-cell}
-def geobox_to_imgbox(bbox_and_chip) -> (pd.DataFrame, xr.Dataset):
+def geobox_to_imgbox(bbox_and_chip) -> (pd.DataFrame, xr.DataArray):
     """
     Convert bounding boxes in a pandas.DataFrame from geographic coordinates
     (minx, miny, maxx, maxy) to image coordinates (x1, y1, x2, y2) based on the
@@ -421,7 +421,7 @@ def boximg_collate_fn(samples) -> (list[torch.Tensor], torch.Tensor, list[dict])
 
     Specifically, the bounding boxes in pandas.DataFrame format are each
     converted to a torch.Tensor and collated into a list, while the raster
-    images in xarray.Dataset format are converted to a torch.Tensor (int16
+    images in xarray.DataArray format are converted to a torch.Tensor (int16
     dtype) and stacked into a single torch.Tensor.
     """
     box_tensors: list[torch.Tensor] = [

--- a/docs/vector-segmentation-masks.md
+++ b/docs/vector-segmentation-masks.md
@@ -278,7 +278,7 @@ print(f"X-range: {canvas.x_range}")
 print(f"Coordinate reference system: {canvas.crs}")
 ```
 
-This information should match the template the Sentinel-1 dataarray 🏁.
+This information should match the template Sentinel-1 dataarray 🏁.
 
 ```{code-cell}
 print(f"Dimensions: {dict(dataarray.sizes)}")

--- a/poetry.lock
+++ b/poetry.lock
@@ -2988,16 +2988,21 @@ viz = ["matplotlib", "nc-time-axis", "seaborn"]
 
 [[package]]
 name = "xbatcher"
-version = "0.1.0"
-description = "Batch generation from xarray dataset"
+version = "0.2.0"
+description = "Batch generation from Xarray objects"
 category = "main"
 optional = true
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 
 [package.dependencies]
 dask = "*"
 numpy = "*"
 xarray = "*"
+
+[package.extras]
+dev = ["adlfs", "asv", "coverage", "pytest", "pytest-cov", "tensorflow", "torch"]
+tensorflow = ["tensorflow"]
+torch = ["torch"]
 
 [[package]]
 name = "xyzservices"
@@ -3052,7 +3057,7 @@ vector = ["pyogrio"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8, <3.12"
-content-hash = "3c168466d744bdc831ee1912aa75cd531857703fbf3dcbf06be551f93af42d0a"
+content-hash = "59f5b26eaac52cbd9a1b8723e0b60985e6af68625b70b7596f6cfe646b1ab1a8"
 
 [metadata.files]
 adal = [
@@ -5163,8 +5168,8 @@ xarray = [
     {file = "xarray-2022.3.0.tar.gz", hash = "sha256:398344bf7d170477aaceff70210e11ebd69af6b156fe13978054d25c48729440"},
 ]
 xbatcher = [
-    {file = "xbatcher-0.1.0-py3-none-any.whl", hash = "sha256:811dbdc5e17a8a42284419a8033adc631998d87d5e3fd502726fe7784d004954"},
-    {file = "xbatcher-0.1.0.tar.gz", hash = "sha256:f09badd59a8821f8976a303f68ca74371a0b29703dc1e70032ff05d38fb5218f"},
+    {file = "xbatcher-0.2.0-py3-none-any.whl", hash = "sha256:1b4cdb6a4c79afd11dc5ce7badea22ddacb7a947e88197c4f5b035dfed7bb907"},
+    {file = "xbatcher-0.2.0.tar.gz", hash = "sha256:70b3da6e6277b57ef5ccfa56fa7e5e81c04d7f7e2bda671629653a7534a81970"},
 ]
 xyzservices = [
     {file = "xyzservices-2022.6.0-py3-none-any.whl", hash = "sha256:eb493eb69bde966788f482e1c3608af99ff18fea8885d795ed1ca3b1a8d2e0ec"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ pystac = {version=">=1.4.0", optional=true}
 pystac-client = {version = ">=0.4.0", optional = true}
 spatialpandas = {version = ">=0.4.0", optional = true}
 stackstac = {version = ">=0.4.0", optional = true}
-xbatcher = {version = ">=0.1.0", optional = true}
+xbatcher = {version = ">=0.2.0", optional = true}
 # Docs
 adlfs = {version = "*", optional = true}
 contextily = {version = "*", optional = true}

--- a/zen3geo/datapipes/xbatcher.py
+++ b/zen3geo/datapipes/xbatcher.py
@@ -104,13 +104,6 @@ class XbatcherSlicerIterDataPipe(IterDataPipe[Union[xr.DataArray, xr.Dataset]]):
 
     def __iter__(self) -> Iterator[Union[xr.DataArray, xr.Dataset]]:
         for dataarray in self.source_datapipe:
-            if hasattr(dataarray, "name") and dataarray.name is None:
-                # Workaround for ValueError: unable to convert unnamed
-                # DataArray to a Dataset without providing an explicit name
-                dataarray = dataarray.to_dataset(
-                    name=xr.backends.api.DATAARRAY_VARIABLE
-                )[xr.backends.api.DATAARRAY_VARIABLE]
-                # dataarray.name = "z"  # doesn't work for some reason
             for chip in dataarray.batch.generator(
                 input_dims=self.input_dims, **self.kwargs
             ):

--- a/zen3geo/datapipes/xbatcher.py
+++ b/zen3geo/datapipes/xbatcher.py
@@ -61,22 +61,27 @@ class XbatcherSlicerIterDataPipe(IterDataPipe[Union[xr.DataArray, xr.Dataset]]):
     ...
     >>> # Sliced window view of xarray.DataArray using DataPipe
     >>> dataarray: xr.DataArray = xr.DataArray(
-    ...     data=np.ones(shape=(3, 128, 128)),
+    ...     data=np.ones(shape=(3, 64, 64)),
     ...     name="foo",
     ...     dims=["band", "y", "x"]
     ... )
     >>> dp = IterableWrapper(iterable=[dataarray])
-    >>> dp_xbatcher = dp.slice_with_xbatcher(input_dims={"y": 64, "x": 64})
+    >>> dp_xbatcher = dp.slice_with_xbatcher(input_dims={"y": 2, "x": 2})
     ...
     >>> # Loop or iterate over the DataPipe stream
     >>> it = iter(dp_xbatcher)
     >>> dataarray_chip = next(it)
     >>> dataarray_chip
-    <xarray.Dataset>
-    Dimensions:  (band: 3, y: 64, x: 64)
+    <xarray.DataArray 'foo' (band: 3, y: 2, x: 2)>
+    array([[[1., 1.],
+            [1., 1.]],
+    <BLANKLINE>
+           [[1., 1.],
+            [1., 1.]],
+    <BLANKLINE>
+           [[1., 1.],
+            [1., 1.]]])
     Dimensions without coordinates: band, y, x
-    Data variables:
-        foo      (band, y, x) float64 1.0 1.0 1.0 1.0 1.0 ... 1.0 1.0 1.0 1.0 1.0
     """
 
     def __init__(


### PR DESCRIPTION
Using [xbatcher v0.2.0](https://github.com/xarray-contrib/xbatcher/releases/tag/v0.2.0) released 27 Oct 2022 which comes with better `xarray.DataArray`/`xarray.Dataset` compatibility implemented in https://github.com/xarray-contrib/xbatcher/pull/71. Setting the minimum version to v0.2.0 instead of v0.1.0 allows us to remove a workaround with the `xarray.DataArray` name not being set (see 147f2704e1896e9fab4065e943500133bf6f2c24). Tutorials also need to be updated, as some code can now be simplified with `xarray.DataArray` being returned rather than `xarray.Dataset`.

Bumps [xbatcher](https://github.com/xarray-contrib/xbatcher) from 0.1.0 to 0.2.0.
- [Release notes](https://github.com/xarray-contrib/xbatcher/releases)
- [Commits](https://github.com/xarray-contrib/xbatcher/compare/0.1.0...v0.2.0)