### PR TITLE
:package: Publish to TestPyPI and PyPI via OpenID Connect token

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -23,6 +23,9 @@ jobs:
   publish-pypi:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
     runs-on: ubuntu-22.04
+    permissions:
+      # This permission is mandatory for OIDC publishing
+      id-token: write
     if: github.repository == 'weiji14/zen3geo'
 
     steps:
@@ -58,14 +61,11 @@ jobs:
           ls -lh dist/
 
       - name: Publish distribution 📦 to Test PyPI
-        uses: pypa/gh-action-pypi-publish@0fc90bca7acbb84292e0cff399f8579284fcfc7d
+        uses: pypa/gh-action-pypi-publish@a3a3bafbb3e5a75a854ae1bc53ae128cf22c4af4
         with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
           skip_existing: true
 
       - name: Publish distribution 📦 to PyPI
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@0fc90bca7acbb84292e0cff399f8579284fcfc7d
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@a3a3bafbb3e5a75a854ae1bc53ae128cf22c4af4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,14 @@ classifiers = [
 ]
 exclude = ["zen3geo/tests"]
 
+[tool.poetry.urls]
+"Homepage" = "https://github.com/weiji14/zen3geo/discussions"
+"Changelog" = "https://zen3geo.readthedocs.io/en/latest/changelog.html"
+"Documentation" = "https://zen3geo.readthedocs.io"
+"Download" = "https://anaconda.org/conda-forge/zen3geo"
+"Source Code" = "https://github.com/weiji14/zen3geo"
+"Sponsor" = "https://github.com/sponsors/weiji14"
+
 [tool.poetry.dependencies]
 # Required
 python = ">=3.8, <4.0"


### PR DESCRIPTION
Using a short-lived API token generated by OpenID Connect (OIDC) instead of a long-lived secret to publish packages to TestPyPI and PyPI.

References:
- https://github.com/pypa/gh-action-pypi-publish/tree/v1.8.1#ipublishing-with-openid-connect
- https://github.com/pypi/warehouse/issues/12965
- https://github.com/pypi/pypi-oidc-private-beta-community