### PR TITLE
:children_crossing: Walkthrough on handling multi-resolution climate data

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -48,6 +48,9 @@ sphinx:
       datashader:
         - 'https://datashader.org/'
         - null
+      datatree:
+        - 'https://xarray-datatree.readthedocs.io/en/latest/'
+        - null
       geopandas:
         - 'https://geopandas.org/en/latest/'
         - null

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -15,6 +15,8 @@ chapters:
         file: object-detection-boxes
       - title: 🏳️‍🌈 Stacking layers
         file: stacking
+      - title: 📶 Multi-resolution
+        file: multi-resolution
   - title: 📖 API Reference
     file: api
   - title: 📆 Changelog

--- a/docs/multi-resolution.md
+++ b/docs/multi-resolution.md
@@ -28,14 +28,15 @@ minimizing memory usage. By the end of the lesson, you should be able to:
 
 - Find 🔍 low and high spatial resolution climate datasets and load them from
   {doc}`Zarr <zarr:index>` stores
-- Stack 🥞 and subset different spatial resolution datasets in a hierarchical
-  {py:class}`datatree.DataTree` structure
-- Slice 🔪 the multi-resolution dataset into chips and pass into a DataLoader
+- Stack 🥞 and subset time-series datasets with different spatial resolutions
+  stored in a hierarchical {py:class}`datatree.DataTree` structure
+- Slice 🔪 the multi-resolution dataset along the time-axis into monthly bins
 
 🔗 Links:
 - https://carbonplan.org/research/cmip6-downscaling-explainer
 - https://github.com/carbonplan/cmip6-downscaling/blob/1.0/notebooks/accessing_data_example.ipynb
 - https://github.com/xarray-contrib/xbatcher/issues/93
+
 
 ## 🎉 **Getting started**
 
@@ -59,7 +60,7 @@ that is in its original low 🔅 spatial resolution, and another one of a
 higher 🔆 spatial resolution. Specifically, we'll be looking at the maximum
 temperature 🌡️ (tasmax) variable from one of the Coupled Model Intercomparison
 Project Phase 6 (CMIP6) global coupled ocean-atmosphere general circulation
-model (GCM) 💨 outputs that is of low resolution (67.5 arcminute), and a
+model (GCM) 💨 outputs that is of low-resolution (67.5 arcminute), and a
 super-resolution product from DeepSD 🤔 that is of a higher resolution (15
 arcminute).
 
@@ -178,7 +179,7 @@ dp_lowres_dataset_180 = dp_lowres_dataset.map(fn=shift_longitude_360_to_180)
 dp_lowres_dataset_180
 ```
 
-Double check that the low resolution 🔆 grid's longitude coordinates 🔢 are now
+Double check that the low-resolution 🔆 grid's longitude coordinates 🔢 are now
 in the -180° to +180° range.
 
 ```{code-cell}
@@ -225,7 +226,7 @@ def multires_collate_fn(lowres_and_highres: tuple) -> DataTree:
     # Turn 2 xr.Dataset objects into 1 xr.DataTree with multiple groups
     ds_lowres, ds_highres = lowres_and_highres
 
-    # Create datacube with lowres and highres groups
+    # Create DataTree with lowres and highres groups
     datatree: DataTree = DataTree.from_dict(
         d={"lowres": ds_lowres.tasmax, "highres": ds_highres.tasmax}
     )
@@ -279,7 +280,8 @@ datatree_subset = next(it)
 datatree_subset
 ```
 
-Let's plot the projected temperature 🌡️ for Dec 2030 to ensure things look ok.
+Let's plot the projected temperature 🌡️ for Dec 2030 over the Philippine
+Archipelago to ensure things look ok.
 
 ```{code-cell}
 ds_lowres = (

--- a/docs/multi-resolution.md
+++ b/docs/multi-resolution.md
@@ -1,0 +1,111 @@
+---
+jupytext:
+  formats: md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+---
+
+# Multi-resolution
+
+> On top of a hundred foot pole you linger
+>
+> Clinging to the first mark of the scale
+>
+> How do you proceed higher?
+>
+> It will take more than a leap of faith
+
+Earth Observation 🛰️ and climate projection 🌡️ data can be captured at
+different levels of detail. In this lesson, we'll work with a multitude of
+spatial resolutions 📏, learning to respect the ground sampling distance or
+native resolution 🔬 of the physical variable being measured, while 🪶
+minimizing memory usage. By the end of the lesson, you should be able to:
+
+- Find 🔍 low and high spatial resolution climate datasets and load them from
+  Zarr stores
+- Stack 🥞 different spatial resolution datasets into an xarray.DataTree
+- Slice 🔪 the multi-resolution dataset into chips and pass into a DataLoader
+
+🔗 Links:
+- https://carbonplan.org/research/cmip6-downscaling-explainer
+- https://github.com/carbonplan/cmip6-downscaling/blob/1.0/notebooks/accessing_data_example.ipynb
+- https://github.com/xarray-contrib/xbatcher/issues/93
+
+## 🎉 **Getting started**
+
+These are the tools 🛠️ you'll need.
+
+```{code-cell}
+import torchdata
+import xpystac
+import zen3geo
+```
+
+## 0️⃣ Find Zarr stores 🧊
+
+The two datasets we'll be working with are 🌐 gridded climate projections, one
+that is in its original low 🔅 spatial resolution, and another one of a
+higher 🔆 spatial resolution. Specifically, we'll be looking at the maximum
+temperature 🌡️ (tasmax) variable from one of the Coupled Model Intercomparison
+Project Phase 6 (CMIP6) global coupled ocean-atmosphere general circulation
+model (GCM) 💨 outputs that is of low resolution (1.125 arc degrees), and a
+super-resolution product from DeepSD 🤔 that is of a higher resolution (0.25
+arc degrees).
+
+```{note}
+The following tutorial will use the term super-resolution 🔭 from Computer
+Vision instead of downscaling ⏬. It's just that the term downscaling ⏬ (going
+from low to high resolution) can get confused with downsampling 🙃 (going from
+high to low resolution), whereas super-resolution 🔭 is unambiguously about
+going from low 🔅 to high 🔆 resolution.
+```
+
+🔖 References:
+- https://carbonplan.org/research/cmip6-downscaling
+- https://github.com/tjvandal/deepsd
+- https://tutorial.xarray.dev/intermediate/cmip6-cloud.html
+
+```{code-cell}
+lowres_raw = "https://cpdataeuwest.blob.core.windows.net/cp-cmip/cmip6/ScenarioMIP/MRI/MRI-ESM2-0/ssp585/r1i1p1f1/Amon/tasmax/gn/v20191108"
+highres_deepsd = "https://cpdataeuwest.blob.core.windows.net/cp-cmip/version1/data/DeepSD/ScenarioMIP.MRI.MRI-ESM2-0.ssp585.r1i1p1f1.month.DeepSD.tasmax.zarr"
+```
+
+The :doc:`Zarr <zarr:index>` stores 🧊 can be loaded into an
+{py:class}`xarray.Dataset` via {py:class}`zen3geo.datapipes.XpySTACAssetReader`
+(functional name: ``read_from_xpystac``) with the `engine="zarr"` keyword
+argument.
+
+```{code-cell}
+dp_lowres = torchdata.datapipes.iter.IterableWrapper(iterable=[lowres_raw])
+dp_highres = torchdata.datapipes.iter.IterableWrapper(iterable=[highres_deepsd])
+
+dp_lowres_dataset = dp_lowres.read_from_xpystac(engine="zarr", chunks="auto")
+dp_highres_dataset = dp_highres.read_from_xpystac(engine="zarr", chunks="auto")
+```
+
+### Inspect the climate datasets 🔥
+
+Let's now preview 👀 the low-resolution 🔅 and high-resolution 🔆 temperature
+datasets.
+
+```{code-cell}
+it = iter(dp_lowres_dataset)
+ds_lowres = next(it)
+print(ds_lowres)
+```
+
+```{code-cell}
+it = iter(dp_highres_dataset)
+ds_highres = next(it)
+print(ds_highres)
+```
+
+Notice that the low-resolution 🔅 dataset has lon/lat pixels of shape
+(320, 160), whereas the high-resolution 🔆 dataset is of shape (1440, 720). So
+there has been a 4.5x increase 📈 in spatial resolution going from the raw GCM
+🌐 grid to the super-resolution 🔭 DeepSD grid.

--- a/poetry.lock
+++ b/poetry.lock
@@ -4859,28 +4859,43 @@ test = ["pytest (>=3.0.0)"]
 
 [[package]]
 name = "xarray"
-version = "2022.3.0"
+version = "2022.6.0"
 description = "N-D labeled arrays and datasets in Python"
 category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "xarray-2022.3.0-py3-none-any.whl", hash = "sha256:560f36eaabe7a989d5583d37ec753dd737357aa6a6453e55c80bb4f92291a69e"},
-    {file = "xarray-2022.3.0.tar.gz", hash = "sha256:398344bf7d170477aaceff70210e11ebd69af6b156fe13978054d25c48729440"},
+    {file = "xarray-2022.6.0-py3-none-any.whl", hash = "sha256:c052208afc3f261984049f28b962d64eb6741a7967898315642f5da85448b6b0"},
+    {file = "xarray-2022.6.0.tar.gz", hash = "sha256:1028d198493f66bb15bd35dcfdd11defd831cbee3af6589fff16f41bddd67e84"},
 ]
 
 [package.dependencies]
-numpy = ">=1.18"
+numpy = ">=1.19"
 packaging = ">=20.0"
-pandas = ">=1.1"
+pandas = ">=1.2"
 
 [package.extras]
-accel = ["bottleneck", "numbagg", "scipy"]
-complete = ["bottleneck", "cfgrib", "cftime", "dask[complete]", "fsspec", "h5netcdf", "matplotlib", "nc-time-axis", "netCDF4", "numbagg", "pooch", "pydap", "rasterio", "scipy", "seaborn", "zarr"]
-docs = ["bottleneck", "cfgrib", "cftime", "dask[complete]", "fsspec", "h5netcdf", "ipykernel", "ipython", "jupyter-client", "matplotlib", "nbsphinx", "nc-time-axis", "netCDF4", "numbagg", "pooch", "pydap", "rasterio", "scanpydoc", "scipy", "seaborn", "sphinx-autosummary-accessors", "sphinx-rtd-theme", "zarr"]
+accel = ["bottleneck", "flox", "numbagg", "scipy"]
+complete = ["bottleneck", "cfgrib", "cftime", "dask[complete]", "flox", "fsspec", "h5netcdf", "matplotlib", "nc-time-axis", "netCDF4", "numbagg", "pooch", "pydap", "rasterio", "scipy", "seaborn", "zarr"]
+docs = ["bottleneck", "cfgrib", "cftime", "dask[complete]", "flox", "fsspec", "h5netcdf", "ipykernel", "ipython", "jupyter-client", "matplotlib", "nbsphinx", "nc-time-axis", "netCDF4", "numbagg", "pooch", "pydap", "rasterio", "scanpydoc", "scipy", "seaborn", "sphinx-autosummary-accessors", "sphinx-rtd-theme", "zarr"]
 io = ["cfgrib", "cftime", "fsspec", "h5netcdf", "netCDF4", "pooch", "pydap", "rasterio", "scipy", "zarr"]
 parallel = ["dask[complete]"]
 viz = ["matplotlib", "nc-time-axis", "seaborn"]
+
+[[package]]
+name = "xarray-datatree"
+version = "0.0.10"
+description = "Hierarchical tree-like data structures for xarray"
+category = "main"
+optional = true
+python-versions = ">=3.8"
+files = [
+    {file = "xarray-datatree-0.0.10.tar.gz", hash = "sha256:71cfb4b881eed816e2967e4fbf3b5d2f19c30cc19aefe95531ab7209d0ce5366"},
+    {file = "xarray_datatree-0.0.10-py3-none-any.whl", hash = "sha256:cfc762296915888e0020457b78f0b908514be67ac49d8cbb0ca571161c136a32"},
+]
+
+[package.dependencies]
+xarray = ">=2022.6.0"
 
 [[package]]
 name = "xbatcher"
@@ -5061,7 +5076,7 @@ docs = ["jaraco.packaging (>=9)", "rst.linker (>=1.9)", "sphinx"]
 testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [extras]
-docs = ["adlfs", "contextily", "datashader", "graphviz", "jupyter-book", "matplotlib", "planetary-computer", "pyogrio", "pystac", "pystac-client", "stackstac", "spatialpandas", "xbatcher", "xpystac", "zarr"]
+docs = ["adlfs", "contextily", "datashader", "graphviz", "jupyter-book", "matplotlib", "planetary-computer", "pyogrio", "pystac", "pystac-client", "stackstac", "spatialpandas", "xarray-datatree", "xbatcher", "xpystac", "zarr"]
 raster = ["xbatcher", "zarr"]
 spatial = ["datashader", "spatialpandas"]
 stac = ["pystac", "pystac-client", "stackstac", "xpystac"]
@@ -5070,4 +5085,4 @@ vector = ["pyogrio"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8, <4.0"
-content-hash = "90dfbece41b0ddeecc3b882e82574ef0ac8c40b51fca9c7e201343d92595e4d1"
+content-hash = "3f7035ab13e9026fd1b848930891b2e105ece1760c5f8bd026b98367c0876636"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ graphviz = {version = "*", optional = true}
 jupyter-book = {version="*", optional=true}
 matplotlib = {version = "*", optional = true}
 planetary-computer = {version="*", optional=true}
+xarray-datatree = {version="*", optional=true}
 
 [tool.poetry.group.dev.dependencies]
 aiohttp = "*"
@@ -70,6 +71,7 @@ docs = [
     "pystac_client",
     "stackstac",
     "spatialpandas",
+    "xarray-datatree",
     "xbatcher",
     "xpystac",
     "zarr"


### PR DESCRIPTION
Tutorial on loading climate datasets with different spatial resolutions for a super-resolution task. Will be looking at one of the CMIP6 model outputs and CarbonPlan's super-resolution (DeepSD) product.

**Preview** at https://zen3geo--91.org.readthedocs.build/en/91/multi-resolution.html

![Maximum temperature from a Global Climate Model output versus a super-resolution downscaled output](https://user-images.githubusercontent.com/23487320/229979146-6dde748b-8ca7-4f6a-8aaa-9e8e16280f6e.png)

TODO:

- [x] Show how to load Zarr datasets using xarray
- [x] Stack different spatial resolution datasets into an `xarray.DataTree`
- [ ] Slice the `xarray.DataTree` into chips

References:
- https://carbonplan.org/research/cmip6-downscaling-explainer
- https://github.com/xarray-contrib/xbatcher/pull/171