### PR TITLE
:bug: Fix DatashaderRasterizer to allow N:1 instead of just 1:1

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,6 +16,10 @@ build:
       # Generate the Sphinx configuration for this Jupyter Book so it builds.
       # https://jupyterbook.org/en/stable/publish/readthedocs.html
       - "jupyter-book config sphinx docs/"
+    post_install:
+      # Install numpy=1.23 instead of 1.24 to prevent AttributeError, see
+      # https://github.com/holoviz/datashader/issues/1209
+      - "pip install numpy==1.23.*"
 
 python:
   install:

--- a/zen3geo/datapipes/datashader.py
+++ b/zen3geo/datapipes/datashader.py
@@ -175,7 +175,7 @@ class DatashaderRasterizerIterDataPipe(IterDataPipe):
 
         len_vector_datapipe: int = len(self.vector_datapipe)
         len_canvas_datapipe: int = len(self.source_datapipe)
-        if len_vector_datapipe != 1 or len_vector_datapipe != len_canvas_datapipe:
+        if len_vector_datapipe != 1 and len_vector_datapipe != len_canvas_datapipe:
             raise ValueError(
                 f"Unmatched lengths for the canvas datapipe ({self.source_datapipe}) "
                 f"and vector datapipe ({self.vector_datapipe}). \n"

--- a/zen3geo/tests/test_datapipes_datashader.py
+++ b/zen3geo/tests/test_datapipes_datashader.py
@@ -10,6 +10,7 @@ from zen3geo.datapipes import DatashaderRasterizer, XarrayCanvas
 
 datashader = pytest.importorskip("datashader")
 
+
 # %%
 @pytest.fixture(scope="function", name="canvas")
 def fixture_canvas():
@@ -83,7 +84,7 @@ def test_datashader_rasterize_vector_geometry(canvas, geodataframe, geom_type, s
     geopandas.GeoDataFrame of point, line or polygon type into an
     xarray.DataArray grid.
     """
-    dp = IterableWrapper(iterable=[canvas])
+    dp = IterableWrapper(iterable=[canvas, canvas])
 
     vector = geodataframe[geodataframe.type.str.contains(geom_type)]
     dp_vector = IterableWrapper(iterable=[vector])
@@ -93,7 +94,7 @@ def test_datashader_rasterize_vector_geometry(canvas, geodataframe, geom_type, s
     # Using functional form (recommended)
     dp_datashader = dp.rasterize_with_datashader(vector_datapipe=dp_vector)
 
-    assert len(dp_datashader) == 1
+    assert len(dp_datashader) == 2
     it = iter(dp_datashader)
     dataarray = next(it)
 


### PR DESCRIPTION
Used the wrong boolean operator (should be and, not or) which meant DatashaderRasterizer didn't work when the vector_datapipe was length 1 and canvas_datapipe was length 2 or more. This prevents false errors like `ValueError: Unmatched lengths for the canvas datapipe (XarrayCanvasIterDataPipe) and vector datapipe (PyogrioReaderIterDataPipe). The vector datapipe's length (1) should either be (1) to allow for broadcasting, or match the canvas datapipe's length of (2)`.

Patches the bugfix at #39 from zen3geo v0.3.0. Also updated a unit test to use a 2:1 canvas:vector ratio to prevent regression.