### PR TITLE
:bug: Fix DatashaderRasterizer for GeoDataFrame wrapped in StreamWrapper

### DIFF
--- a/zen3geo/datapipes/datashader.py
+++ b/zen3geo/datapipes/datashader.py
@@ -214,8 +214,7 @@ class DatashaderRasterizerIterDataPipe(IterDataPipe):
             # Convert vector to spatialpandas format to allow datashader's
             # rasterization methods to work
             try:
-                columns = ["geometry"] if not hasattr(vector, "columns") else None
-                _vector = spatialpandas.GeoDataFrame(data=vector, columns=columns)
+                _vector = spatialpandas.GeoDataFrame(data=vector.geometry)
             except ValueError as e:
                 if str(e) == "Unable to convert data argument to a GeometryList array":
                     raise NotImplementedError(

--- a/zen3geo/datapipes/datashader.py
+++ b/zen3geo/datapipes/datashader.py
@@ -217,10 +217,14 @@ class DatashaderRasterizerIterDataPipe(IterDataPipe):
                 columns = ["geometry"] if not hasattr(vector, "columns") else None
                 _vector = spatialpandas.GeoDataFrame(data=vector, columns=columns)
             except ValueError as e:
-                raise NotImplementedError(
-                    f"Unsupported geometry type(s) {set(vector.geom_type)} detected, "
-                    "only point, line or polygon vector geometry types are supported."
-                ) from e
+                if str(e) == "Unable to convert data argument to a GeometryList array":
+                    raise NotImplementedError(
+                        f"Unsupported geometry type(s) {set(vector.geom_type)} detected, "
+                        "only point, line or polygon vector geometry types "
+                        "(or their multi- equivalents) are supported."
+                    ) from e
+                else:
+                    raise e
 
             # Determine geometry type to know which rasterization method to use
             vector_dtype: spatialpandas.geometry.GeometryDtype = _vector.geometry.dtype


### PR DESCRIPTION
In [`DatashaderRasterizer`](https://zen3geo.readthedocs.io/en/v0.6.0/api.html#zen3geo.datapipes.DatashaderRasterizer) (from zen3geo v0.3.0 to v0.6.0), the conversion of a `geopandas.GeoDataFrame` to `spatialpandas.GeoDataFrame` happens in this try-except statement:

https://github.com/weiji14/zen3geo/blob/377992b996b9f7b4d992215d6eac494676722263/zen3geo/datapipes/datashader.py#L214-L223

This was added at commit 6805418dc8dd52ed28d45ee8520982208a11cba0 in #35. In some rare cases, the conversion fails when the vector geometry is wrapped in a [StreamWrapper](https://pytorch.org/data/0.6/generated/torchdata.datapipes.utils.StreamWrapper.html?highlight=streamwrapper#torchdata.datapipes.utils.StreamWrapper) class (but not always?), due to spatialpandas not being able to detect the presence of a geometry column. The traceback looks like this:

```python-traceback
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
File ~/mambaforge/envs/mlpipeline/lib/python3.10/site-packages/zen3geo/datapipes/datashader.py:218, in DatashaderRasterizerIterDataPipe.__iter__(self)
    217     columns = ["geometry"] if not hasattr(vector, "columns") else None
--> 218     _vector = spatialpandas.GeoDataFrame(data=vector, columns=columns)
    219 except ValueError as e:

File ~/mambaforge/envs/mlpipeline/lib/python3.10/site-packages/spatialpandas/geodataframe.py:35, in GeoDataFrame.__init__(self, data, index, geometry, **kwargs)
     34 if first_geometry_col is None:
---> 35     raise ValueError(
     36         "A spatialpandas GeoDataFrame must contain at least one spatialpandas "
     37         "GeometryArray column"
     38     )
     40 if geometry is None:

ValueError: A spatialpandas GeoDataFrame must contain at least one spatialpandas GeometryArray column

The above exception was the direct cause of the following exception:

NotImplementedError                       Traceback (most recent call last)
Cell In[54], line 2
      1 it = iter(dp_datashader)
----> 2 tmp = next(it)
      4 torchdata.datapipes.utils.to_graph(dp=dp_datashader)

File ~/mambaforge/envs/mlpipeline/lib/python3.10/site-packages/torch/utils/data/datapipes/_hook_iterator.py:173, in hook_iterator.<locals>.wrap_generator(*args, **kwargs)
    171         response = gen.send(None)
    172 else:
--> 173     response = gen.send(None)
    175 while True:
    176     datapipe._number_of_samples_yielded += 1

File ~/mambaforge/envs/mlpipeline/lib/python3.10/site-packages/zen3geo/datapipes/datashader.py:220, in DatashaderRasterizerIterDataPipe.__iter__(self)
    218     _vector = spatialpandas.GeoDataFrame(data=vector, columns=columns)
    219 except ValueError as e:
--> 220     raise NotImplementedError(
    221         f"Unsupported geometry type(s) {set(vector.geom_type)} detected, "
    222         "only point, line or polygon vector geometry types are supported."
    223     ) from e
    225 # Determine geometry type to know which rasterization method to use
    226 vector_dtype: spatialpandas.geometry.GeometryDtype = _vector.geometry.dtype

NotImplementedError: Unsupported geometry type(s) {'Polygon'} detected, only point, line or polygon vector geometry types are supported.
This exception is thrown by __iter__ of DatashaderRasterizerIterDataPipe(agg=None, kwargs={}, source_datapipe=XarrayCanvasIterDataPipe, vector_datapipe=PyogrioReaderIterDataPipe)
```
Relevant logic in spatialpandas is at https://github.com/holoviz/spatialpandas/blob/aeeba42751fd7cc16fd7e4a142b053fb9cd0c033/spatialpandas/geodataframe.py#L26-L32

Since `spatialpandas` doesn't use ducktyping, fixing this would require the `vector` variable to be serialized from a StreamWrapped instance to a `geopandas.GeoDataFrame` or `geopandas.GeoSeries` object. This could happen by:

1. Calling `vector.geometry` which returns a `geopandas.GeoSeries`, and pass that into `spatialpandas.GeoDataFrame`.
2. Calling `vector.loc[:]` to return a view of the `geopandas.GeoDataFrame` or `geopandas.GeoSeries` object.

The bugfix in this PR will use (1), basically following the original logic prior to 6805418dc8dd52ed28d45ee8520982208a11cba0 in #35. Disadvantage is that the columns from the GeoDataFrame will be lost on converting to GeoSeries, but we are not making use of any other column beside the geometry column on the rasterization step anyway (though it is usually nice to not delete data until necessary).

Also, this PR makes the try-except statement catch a more specific ValueError (since the 'Polygon' dtype should be supported). Ideally there would be a unit test to cover the `ValueError: A spatialpandas GeoDataFrame must contain at least one spatialpandas GeometryArray column` case, but it's hard to create a minimal reproducible example, so just testing something that hits the same code line instead.

Patches #35.
