### PR TITLE
:alien: Handle ms-buildings 20230425 update in Object Detection tutorial

### DIFF
--- a/docs/object-detection-boxes.md
+++ b/docs/object-detection-boxes.md
@@ -133,7 +133,8 @@ cloud-native columnar 🀤 geospatial vector file format) over our study area.
 
 ```{code-cell}
 catalog = pystac_client.Client.open(
-    url="https://planetarycomputer.microsoft.com/api/stac/v1"
+    url="https://planetarycomputer.microsoft.com/api/stac/v1",
+    modifier=planetary_computer.sign_inplace,
 )
 items = catalog.search(
     collections=["ms-buildings"], query={"msbuildings:region": {"eq": "Brunei"}}
@@ -142,11 +143,18 @@ item = next(items.get_items())
 item
 ```
 
-Next, we'll sign 🔏 the URL to the STAC Item Asset, and load ⤵️ the GeoParquet
-file using {py:func}`geopandas.read_parquet`.
+```{note}
+Accessing the building footprint STAC Assets from Planetary Computer will
+require signing 🔏 the URL. This can be done with a `modifier` function in the
+{py:meth}`pystac_client.Client.open` call. See also 'Automatically modifying
+results' under {doc}`PySTAC-Client Usage <pystac_client:usage>`).
+```
+
+Next, we'll load ⤵️ the GeoParquet file using
+{py:func}`geopandas.read_parquet`.
 
 ```{code-cell}
-asset = planetary_computer.sign(item.assets["data"])
+asset = item.assets["data"]
 
 geodataframe = gpd.read_parquet(
     path=asset.href, storage_options=asset.extra_fields["table:storage_options"]

--- a/docs/object-detection-boxes.md
+++ b/docs/object-detection-boxes.md
@@ -129,7 +129,8 @@ dataarray
 
 Now to pull in some building footprints 🛖. Let's make a STAC API query to get
 a [GeoParquet](https://github.com/opengeospatial/geoparquet) file (a
-cloud-native columnar 🀤 geospatial vector file format) over our study area.
+cloud-native columnar 🀤 geospatial vector file format) that intersects our
+study area.
 
 ```{code-cell}
 catalog = pystac_client.Client.open(
@@ -137,7 +138,9 @@ catalog = pystac_client.Client.open(
     modifier=planetary_computer.sign_inplace,
 )
 items = catalog.search(
-    collections=["ms-buildings"], query={"msbuildings:region": {"eq": "Brunei"}}
+    collections=["ms-buildings"],
+    query={"msbuildings:region": {"eq": "Brunei"}},
+    intersects=shapely.geometry.box(minx=114.94, miny=4.88, maxx=114.95, maxy=4.89),
 )
 item = next(items.get_items())
 item
@@ -163,10 +166,11 @@ geodataframe
 ```
 
 This {py:class}`geopandas.GeoDataFrame` contains building outlines across
-Brunei 🇧🇳. Let's do a spatial subset ✂️ to just the Kampong Ayer study area
-using {py:attr}`geopandas.GeoDataFrame.cx`, and reproject it using
-{py:meth}`geopandas.GeoDataFrame.to_crs` to match the coordinate reference
-system of the optical image.
+Brunei 🇧🇳 that intersects and extends beyond our study area. Let's do a spatial
+subset ✂️ to just the Kampong Ayer study area using
+{py:attr}`geopandas.GeoDataFrame.cx`, and reproject the polygon coordinates
+using {py:meth}`geopandas.GeoDataFrame.to_crs` to match the coordinate
+reference system of the optical image.
 
 ```{code-cell}
 _gdf_kpgayer = geodataframe.cx[114.94:114.95, 4.88:4.89]


### PR DESCRIPTION
The Microsoft Building footprint dataset was updated on 25 April 2023 to a Delta Lake storage format, which changed the schema and added an extra layer on top of the geoparquet files designed for faster bounding box based queries. The old method of filtering just by a `msbuildings:region` attribute from #49 now fails however, so need to add a bounding box region argument to the intersect parameter when performing the STAC API search.

**Preview** at https://zen3geo--106.org.readthedocs.build/en/106/object-detection-boxes.html#load-cloud-native-vector-files

| [Broken](https://zen3geo--104.org.readthedocs.build/en/104/object-detection-boxes.html#load-cloud-native-vector-files) | [Fixed](https://zen3geo--106.org.readthedocs.build/en/106/object-detection-boxes.html#load-cloud-native-vector-files) |
|--|--|
| ![image](https://github.com/weiji14/zen3geo/assets/23487320/ab6a12b4-1cba-4aa2-a096-96fd73b93410) | ![image](https://github.com/weiji14/zen3geo/assets/23487320/aed025c6-927e-446b-8658-592a0def6574) |

Note that documentation was ok at zen3geo v0.6.0 released on 20230418 (see https://zen3geo.readthedocs.io/en/v0.6.0/object-detection-boxes.html#load-cloud-native-vector-files) as it was a week prior to the ms-building 20230425 update :relieved:. This patch will make it to zen3geo v0.6.1.


References:
- https://web.archive.org/web/20230315044820/https://planetarycomputer.microsoft.com/dataset/ms-buildings#Example-Notebook
- https://github.com/microsoft/PlanetaryComputer/discussions/201#discussioncomment-5904577