### PR TITLE
:truck: Move readthedocs config file under docs folder

### DIFF
--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -1,10 +1,10 @@
-# Read the Docs configuration file
+# Read the Docs configuration file for Sphinx projects
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
 # Required
 version: 2
 
-# Set the version of Python and other tools you might need
+# Set the OS, Python version and other tools you might need
 build:
   os: ubuntu-22.04
   tools:
@@ -17,6 +17,9 @@ build:
       # https://jupyterbook.org/en/stable/publish/readthedocs.html
       - "jupyter-book config sphinx docs/"
 
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
   install:
     - method: pip


### PR DESCRIPTION
One less file in the root directory! Moved `.readthedocs.yml` to `docs/.readthedocs.yml` and added some extra comments too.

References:
- https://docs.readthedocs.io/en/stable/guides/setup/monorepo.html#how-to-use-a-readthedocs-yaml-file-in-a-sub-folder
- https://github.com/readthedocs/readthedocs.org/pull/10001