### PR TITLE
:pencil2: Edit Sentinel-1 preview PNG urls from Planetary Computer

### DIFF
--- a/docs/chipping.md
+++ b/docs/chipping.md
@@ -88,7 +88,7 @@ da
 
 This is how the Sentinel-1 radar image looks like over Osaka on 14 June 2022.
 
-![Sentinel-1 image over Osaka, Japan on 20220614](https://planetarycomputer.microsoft.com/api/data/v1/item/preview.png?collection=sentinel-1-grd&item=S1A_IW_GRDH_1SDV_20220614T210034_20220614T210059_043664_05368A&assets=vv&assets=vh&expression=vv%2Cvh%2Cvv%2Fvh&rescale=0%2C500&rescale=0%2C300&rescale=0%2C7&tile_format=png)
+![Sentinel-1 GRD image over Osaka, Japan on 20220614](https://planetarycomputer.microsoft.com/api/data/v1/item/preview.png?collection=sentinel-1-grd&item=S1A_IW_GRDH_1SDV_20220614T210034_20220614T210059_043664_05368A&assets=vv&assets=vh&expression=vv%3Bvh%3Bvv%2Fvh&rescale=0%2C600&rescale=0%2C270&rescale=0%2C9&asset_as_band=True&tile_format=png&format=png)
 
 ## 1️⃣ Creating 512x512 chips from large satellite scenes 🪟
 

--- a/docs/stacking.md
+++ b/docs/stacking.md
@@ -75,7 +75,7 @@ obtained via a spatiotemporal query to a [STAC](https://stacspec.org) API.
 This is how the Sentinel-1 radar image looks like over Sumatra Barat, Indonesia
 on 23 February 2022, two days before the earthquake.
 
-![Sentinel-1 image over Sumatra Barat, Indonesia on 20220223](https://planetarycomputer.microsoft.com/api/data/v1/item/preview.png?collection=sentinel-1-rtc&item=S1A_IW_GRDH_1SDV_20220223T114141_20220223T114206_042039_0501F9_rtc&assets=vv&assets=vh&tile_format=png&expression=0.03+%2B+log+%2810e-4+-+log+%280.05+%2F+%280.02+%2B+2+%2A+vv%29%29%29%2C0.05+%2B+exp+%280.25+%2A+%28log+%280.01+%2B+2+%2A+vv%29+%2B+log+%280.02+%2B+5+%2A+vh%29%29%29%2C1+-+log+%280.05+%2F+%280.045+-+0.9+%2A+vv%29%29&rescale=0%2C.8000&rescale=0%2C1.000&rescale=0%2C1.000)
+![Sentinel-1 RTC image over Sumatra Barat, Indonesia on 20220223](https://planetarycomputer.microsoft.com/api/data/v1/item/preview.png?collection=sentinel-1-rtc&item=S1A_IW_GRDH_1SDV_20220223T114141_20220223T114206_042039_0501F9_rtc&assets=vv&assets=vh&tile_format=png&expression=0.03+%2B+log+%2810e-4+-+log+%280.05+%2F+%280.02+%2B+2+%2A+vv%29%29%29%3B0.05+%2B+exp+%280.25+%2A+%28log+%280.01+%2B+2+%2A+vv%29+%2B+log+%280.02+%2B+5+%2A+vh%29%29%29%3B1+-+log+%280.05+%2F+%280.045+-+0.9+%2A+vv%29%29&asset_as_band=True&rescale=0%2C.8000&rescale=0%2C1.000&rescale=0%2C1.000&format=png)
 
 ### Sentinel-1 PolSAR time-series ⏳
 

--- a/docs/vector-segmentation-masks.md
+++ b/docs/vector-segmentation-masks.md
@@ -68,7 +68,7 @@ signed_item
 This is how the Sentinel-1 🩻 image looks like over Johor in Peninsular
 Malaysia on 15 Dec 2019.
 
-![Sentinel-1 image over Johor, Malaysia on 20191215](https://planetarycomputer.microsoft.com/api/data/v1/item/preview.png?collection=sentinel-1-grd&item=S1A_IW_GRDH_1SDV_20191215T224757_20191215T224822_030365_037955&assets=vv&assets=vh&expression=vv%2Cvh%2Cvv%2Fvh&rescale=0%2C500&rescale=0%2C300&rescale=0%2C7&tile_format=png)
+![Sentinel-1 GRD image over Johor, Malaysia on 20191215](https://planetarycomputer.microsoft.com/api/data/v1/item/preview.png?collection=sentinel-1-grd&item=S1A_IW_GRDH_1SDV_20191215T224757_20191215T224822_030365_037955&assets=vv&assets=vh&expression=vv%3Bvh%3Bvv%2Fvh&rescale=0%2C600&rescale=0%2C270&rescale=0%2C9&asset_as_band=True&tile_format=png&format=png)
 
 ### Load and reproject image data 🔄
 

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -82,7 +82,7 @@ da
 
 This is how the Sentinel-2 image looks like over Singapore on 15 Jan 2022.
 
-![Sentinel-2 image over Singapore on 20220115](https://planetarycomputer.microsoft.com/api/data/v1/item/preview.png?collection=sentinel-2-l2a&item=S2A_MSIL2A_20220115T032101_R118_T48NUG_20220115T170435&assets=visual&asset_bidx=visual%7C1%2C2%2C3&nodata=0)
+![Sentinel-2 L2A image over Singapore on 20220115](https://planetarycomputer.microsoft.com/api/data/v1/item/preview.png?collection=sentinel-2-l2a&item=S2A_MSIL2A_20220115T032101_R118_T48NUG_20220115T170435&assets=visual&asset_bidx=visual%7C1%2C2%2C3&nodata=0&format=png)
 
 ## 1️⃣ Construct [DataPipe](https://github.com/pytorch/data/tree/v0.6.1#what-are-datapipes) 📡
 


### PR DESCRIPTION
Need to add `&asset_as_band=True` to the PNG preview URLs for the Sentinel-1 GRD and RTC images on Planetary Computer now, possibly due to updated Titiler version (see https://planetarycomputer.microsoft.com/docs/changelogs/history#january-2023). Also clarified whether the preview image is Sentinel-1 RTC or GRD, and did the same for the Sentinel-2 L2A preview.

**Preview** at https://zen3geo--129.org.readthedocs.build/en/129/chipping.html

In case the URLs change again, these are the Planetary Computer explorer links to the Sentinel-1/Sentinel-2 images:
- Sentinel-2 L2A image over Singapore on 20220115 - https://planetarycomputer.microsoft.com/explore?c=103.6957%2C1.3129&z=8.70&v=2&d=sentinel-2-l2a&s=false%3A%3A100%3A%3Atrue&sr=desc&ae=0&m=cql%3Adffe43c8e7b4dfe4d883e0475848ba22&r=Natural+color
- Sentinel-1 GRD image over Johor, Malaysia on 20191215 - https://planetarycomputer.microsoft.com/explore?c=104.0106%2C1.8523&z=7.71&v=2&d=sentinel-1-grd&m=cql%3Aea687c9f9c3f69afa49e900ea3347143&r=VV%2C+VH+False-color+composite&s=false%3A%3A100%3A%3Atrue&sr=desc&ae=0
- Sentinel-1 RTC image over Sumatra Barat, Indonesia on 20220223 - https://planetarycomputer.microsoft.com/explore?c=99.3051%2C0.0538&z=7.71&v=2&d=sentinel-1-rtc&m=cql%3A5c13464ff5995ad7e3b46c5105da5b4c&r=VV%2C+VH+False-color+composite&s=false%3A%3A100%3A%3Atrue&sr=desc&ae=0
- Sentinel-1 GRD image over Osaka, Japan on 20220614 - https://planetarycomputer.microsoft.com/explore?c=135.2645%2C34.0466&z=7.57&v=2&d=sentinel-1-grd&s=false%3A%3A100%3A%3Atrue&sr=desc&ae=0&m=cql%3Ac03c473974ad2a6afca90643c180e49d&r=VV%2C+VH+False-color+composite

Patches #8, #20, #31, #62