### PR TITLE
:sparkles: LaspyReader for reading LAS/LAZ point cloud files

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -54,6 +54,9 @@ sphinx:
       geopandas:
         - 'https://geopandas.org/en/latest/'
         - null
+      laspy:
+        - 'https://laspy.readthedocs.io/en/latest/'
+        - null
       mmdetection:
         - 'https://mmdetection.readthedocs.io/zh_CN/latest/'
         - null

--- a/docs/api.md
+++ b/docs/api.md
@@ -27,6 +27,15 @@
     :show-inheritance:
 ```
 
+### Laspy
+
+```{eval-rst}
+.. automodule:: zen3geo.datapipes.laspy
+.. autoclass:: zen3geo.datapipes.LaspyReader
+.. autoclass:: zen3geo.datapipes.laspy.LaspyReaderIterDataPipe
+    :show-inheritance:
+```
+
 ### Pyogrio
 
 ```{eval-rst}

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@ Get what you need, not more, not less:
 | Command                        |  Dependencies |
 |:-------------------------------|---------------|
 | `pip install zen3geo`          | rioxarray, torchdata |
+| `pip install zen3geo[lidar]`   | rioxarray, torchdata, laspy[lazrs] |
 | `pip install zen3geo[raster]`  | rioxarray, torchdata, xbatcher, zarr |
 | `pip install zen3geo[spatial]` | rioxarray, torchdata, datashader, spatialpandas |
 | `pip install zen3geo[stac]`    | rioxarray, torchdata, pystac, pystac-client, stackstac, xpystac |
@@ -14,7 +15,7 @@ Get what you need, not more, not less:
 
 Retrieve more ['extras'](https://github.com/weiji14/zen3geo/blob/main/pyproject.toml) using
 
-    pip install zen3geo[raster,spatial,stac,vector]
+    pip install zen3geo[lidar,raster,spatial,stac,vector]
 
 To install the development version from [TestPyPI](https://test.pypi.org/project/zen3geo), do:
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1645,6 +1645,28 @@ files = [
 ]
 
 [[package]]
+name = "laspy"
+version = "2.5.3"
+description = "Native Python ASPRS LAS read/write library"
+optional = true
+python-versions = ">=3.8"
+files = [
+    {file = "laspy-2.5.3.tar.gz", hash = "sha256:4ad698914358ea5a096da52e69bceccd320d9ddfb367480a5c2b5e086db812b7"},
+]
+
+[package.dependencies]
+lazrs = {version = ">=0.5.0,<0.6.0", optional = true, markers = "extra == \"lazrs\""}
+numpy = "*"
+
+[package.extras]
+cli = ["rich (>=10.11.0)", "typer[all] (>=0.8.0)"]
+dev = ["black (==22.3.0)", "coverage", "isort (==5.11.5)", "m2r2", "nox", "pytest", "pytest-benchmark", "rangehttpserver", "sphinx", "sphinx-rtd-theme"]
+laszip = ["laszip (>=0.2.1,<0.3.0)"]
+lazrs = ["lazrs (>=0.5.0,<0.6.0)"]
+pyproj = ["pyproj"]
+requests = ["requests"]
+
+[[package]]
 name = "latexcodec"
 version = "2.0.1"
 description = "A lexer and codec to work with LaTeX code in Python."
@@ -1657,6 +1679,49 @@ files = [
 
 [package.dependencies]
 six = ">=1.4.1"
+
+[[package]]
+name = "lazrs"
+version = "0.5.3"
+description = "Python bindings for laz-rs"
+optional = true
+python-versions = "*"
+files = [
+    {file = "lazrs-0.5.3-cp310-cp310-macosx_10_7_x86_64.whl", hash = "sha256:04f1b65b1bda291f81512ab5f218b4f03cbee12d910483d5d429e678013302d1"},
+    {file = "lazrs-0.5.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:65e7104257aa0b369ea821444d407cbb621bdd63c0b6231e1605864b82f206ac"},
+    {file = "lazrs-0.5.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fd6f107a463235b7f8f374599987673173efbc22bcfaf94ae51e03a0305bea3c"},
+    {file = "lazrs-0.5.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:529c8399f283b1df7246c9b515f497cb11d7e52f9f093fdc6cb99ad591242cc0"},
+    {file = "lazrs-0.5.3-cp310-none-win32.whl", hash = "sha256:3c5d85b825d85aac7443225386403f869c2876fbf7279313ac8eed420c30465e"},
+    {file = "lazrs-0.5.3-cp310-none-win_amd64.whl", hash = "sha256:9a084c04a1e10c4732d5267d8564579dc3694405fd4321b19301de3618518725"},
+    {file = "lazrs-0.5.3-cp311-cp311-macosx_10_7_x86_64.whl", hash = "sha256:651b16021775709f5e4c01d8fc8eba6d33c1fb4e5aeb5a6923636be0848644d2"},
+    {file = "lazrs-0.5.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:504417feeca6dd3767895da4ef5bda636e486844cf60a859020a310e47062316"},
+    {file = "lazrs-0.5.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d995531e3e7816ffc35dbd6edc5a4c37a2bbc18975df5c70b41bc00ba878e43c"},
+    {file = "lazrs-0.5.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:85899e3c6c7af5989d8bfe1446515e8290794b423a0dd3f237dc5d0b3038300a"},
+    {file = "lazrs-0.5.3-cp311-none-win32.whl", hash = "sha256:1325eceb7d2f5e68d91c959f5dc2784ee8ae95c8e1b8e77e8291bab53247530a"},
+    {file = "lazrs-0.5.3-cp311-none-win_amd64.whl", hash = "sha256:bf3604fca629eb754475a2ba9ee9bcb84aea153cea9382b6dc02dafaa310057b"},
+    {file = "lazrs-0.5.3-cp312-cp312-macosx_10_7_x86_64.whl", hash = "sha256:f834c6253a5a1f1627394cd869c5264eac586427c42d20f4e9f18c455d7d3832"},
+    {file = "lazrs-0.5.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5e7976b8ce49e2d44a01289597a6efc1b350b1454619cc00d8c9faffcb4338c4"},
+    {file = "lazrs-0.5.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bd4cbc8deefff760ef7f8e323c22c3934caab180793a2975611633fe09949aac"},
+    {file = "lazrs-0.5.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:42804a7c073ed465504b98380ed62074d696b03edc2fd533bf85e53737f4580a"},
+    {file = "lazrs-0.5.3-cp312-none-win32.whl", hash = "sha256:d8129e7b2fff58799bfd7f2e69e672bf3d180447e79902c770bf8eac22d390bd"},
+    {file = "lazrs-0.5.3-cp312-none-win_amd64.whl", hash = "sha256:7347be3191f934e2dd04b14e2484a1ac0188ac761944ee293bb2519fb2894ddd"},
+    {file = "lazrs-0.5.3-cp37-cp37m-macosx_10_7_x86_64.whl", hash = "sha256:2f7039fd539573e9f7ae6c364ed189b14f7eb73624665a064197944a67a6386f"},
+    {file = "lazrs-0.5.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3168aea3adb13ff2a3606779509a387c963788a2deb39bc5f6dceec034b1e74a"},
+    {file = "lazrs-0.5.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:57d3a772954df77de2cac9aac9029208fee2dccd292f8c7e600cc1f2b276e922"},
+    {file = "lazrs-0.5.3-cp37-none-win32.whl", hash = "sha256:e8c3ef5eeb1fe4c696d90b1b63ad6f96af9343f6ae7e52aa0c29c25c715a181a"},
+    {file = "lazrs-0.5.3-cp37-none-win_amd64.whl", hash = "sha256:37313463305d2fab90ee9987cce22fb875f98f528f77293c57026fa8f0cd7eab"},
+    {file = "lazrs-0.5.3-cp38-cp38-macosx_10_7_x86_64.whl", hash = "sha256:e3ededa9d211afdd8304308a6dc5f11261647fceaf59d3909ffe2038f96d2cd9"},
+    {file = "lazrs-0.5.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f1349f01891a12c77281f1b5529936313e0cb1413125ea0adf925b18a7bf3533"},
+    {file = "lazrs-0.5.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:03f678cd03baa14de56b2da2395f547b2978ee7f9a35ae71bfaff3a5e3fcf67f"},
+    {file = "lazrs-0.5.3-cp38-none-win32.whl", hash = "sha256:1d2d65a9dfce19f61e5ba24b2dcc7031a4b53e21a3f5f6f35ceb663969767825"},
+    {file = "lazrs-0.5.3-cp38-none-win_amd64.whl", hash = "sha256:d319f7a9068654fee364ead4c8c9c24b01f8eccfda66c5d1591dad0f4f04a360"},
+    {file = "lazrs-0.5.3-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:f0054a8d128dd41490a192893e55d723356e9fb82866d1115dac89a390e46308"},
+    {file = "lazrs-0.5.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c13f215b52eb825448064d7033ba59f70d8d2fc45e0d7a9869e8ff0e1bef53b4"},
+    {file = "lazrs-0.5.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b54994d959a0d21cebb24b51aade3660687bbf31c0e5f4f52650768cbc69c75e"},
+    {file = "lazrs-0.5.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:988afdbaa21829a9aa62aa0cdbc8fe4320a6d58561593402d0f5719586026c61"},
+    {file = "lazrs-0.5.3-cp39-none-win32.whl", hash = "sha256:9b0de878aa10506004fa10dcedf4fbcf1a8462cb2b0ba4ceecd9e981b4a07363"},
+    {file = "lazrs-0.5.3-cp39-none-win_amd64.whl", hash = "sha256:6c9f38393ba382bb786bc0a8c4348f34a108113361af3bb7f55df76cb088b12b"},
+]
 
 [[package]]
 name = "linkify-it-py"
@@ -3434,73 +3499,108 @@ files = [
 
 [[package]]
 name = "pyzmq"
-version = "23.1.0"
+version = "25.1.2"
 description = "Python bindings for 0MQ"
 optional = true
 python-versions = ">=3.6"
 files = [
-    {file = "pyzmq-23.1.0-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:6d346e551fa64b89d57a4ac74b9bc66703413f02f50093e089e861999ec5cccc"},
-    {file = "pyzmq-23.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9c7fb691fb07ec7ab99fd173bb0e7e0248d31bf83d484a87b917a342f63812c9"},
-    {file = "pyzmq-23.1.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:cd82cca9c489e441574804dbda2dd8e114cf3be7935b03de11dade2c9478aea6"},
-    {file = "pyzmq-23.1.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:28f9164fb2658b7b414fa0894c75b1a9c61375774cdc1bdb7298beb042a2cd87"},
-    {file = "pyzmq-23.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:53b2c1326c2e484d450932d2be739f064b7cb572faabec38386098a28516a529"},
-    {file = "pyzmq-23.1.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:425ba851a6f9892bde1da2024d82e2fe6796bd77e3391fb96665c50fe9d4c6a5"},
-    {file = "pyzmq-23.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:38f778a74e3889392e949326cfd0e9b2eb37dcbb2980d98fad2c51703d523db2"},
-    {file = "pyzmq-23.1.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:ddf4ad1d651e6c9234945061e1a31fe27a4be0dea21c498b87b186fadf8f5919"},
-    {file = "pyzmq-23.1.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:2b08774057ae7ce8a2eb4e7d54db05358234440706ce43a85814500c5d7bd22e"},
-    {file = "pyzmq-23.1.0-cp310-cp310-win32.whl", hash = "sha256:67ec63ae3c9c1fa2e077fcb42e77035e2121a04f987464bdf9945a28535d30ad"},
-    {file = "pyzmq-23.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:f4c7d370badc60ac94a554bc571a46d03e39d8aacfba8006b334512e184aed59"},
-    {file = "pyzmq-23.1.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f6c9d30888503f2f5f87d6d41f016301352dd98da4a861bd10663c3a2d99d3b5"},
-    {file = "pyzmq-23.1.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:16b832adb5d8716f46051da5533c480250bf126984ce86804db6137a3a7f931b"},
-    {file = "pyzmq-23.1.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:da72a384a1d7e87490ca71182f3ab469ed21d847adc16b70c34faac5a3b12801"},
-    {file = "pyzmq-23.1.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6ab4b6108e69f63c917cd7ef7217c5727955b1ac90600e44a13ed5312019a014"},
-    {file = "pyzmq-23.1.0-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:7626e8384275a7dea6f3d1f749fb5e00299042e9c895fc3dbe24cb154909c242"},
-    {file = "pyzmq-23.1.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:cbc1184349ca6e5112898aa7fc3efa1b1bbae24ab1edc774cfd09cbfd3b091d7"},
-    {file = "pyzmq-23.1.0-cp36-cp36m-win32.whl", hash = "sha256:d977df6f7c4109ed1d96ffb6795f6af77114be606ae4556efbfc9cac725db65d"},
-    {file = "pyzmq-23.1.0-cp36-cp36m-win_amd64.whl", hash = "sha256:2951c29b8649f3672af9dca8ff61d86310d3664d9629788b1c66422fb13b1239"},
-    {file = "pyzmq-23.1.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:bd2a13a0f8367e50347cbac87ae230ae1953935443240238f956bf10668bead6"},
-    {file = "pyzmq-23.1.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6bd7f18bd4cf51ea8d7e54825902cf36f9d2f35cc51ef618373988d5398b8dd0"},
-    {file = "pyzmq-23.1.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fab8a7877275060f7b303e1f91c218069a2814a616b6a5ee2d8a3737deb15915"},
-    {file = "pyzmq-23.1.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:894be7d17228e7328cc188096c0162697211ec91761f6812fff12790cbe11c66"},
-    {file = "pyzmq-23.1.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:bba54f97578943f48f621b4a7afb8eb022370da26a88b88ccc9fee9f3ef7ce45"},
-    {file = "pyzmq-23.1.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:eb0ae5dfda83bbce660179d7b41c1c38fd833a54d2e6d9b258c644f3b75ef94d"},
-    {file = "pyzmq-23.1.0-cp37-cp37m-win32.whl", hash = "sha256:523ba7fd4d8fe75ad09c1e574a648892b75a97d0cfc8005727681053ac19555b"},
-    {file = "pyzmq-23.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:6cd53e861bccc0bdc4620f68fb4a91d5bcfe9f4213cf8e200fa498044d33a6dc"},
-    {file = "pyzmq-23.1.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:81623c67cb71b93b5f7e06c9107f3781738ae86866db830c950223d87af2a235"},
-    {file = "pyzmq-23.1.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:83f1c76068faf62c32a36dd62dc4db642c2027bbbd960f8f6345b59e9d4dc472"},
-    {file = "pyzmq-23.1.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:312e56799410c34797417a4060a8bd37d4db1f06d1ec0c54f7c8fd81e0d90376"},
-    {file = "pyzmq-23.1.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ff8708fabc9f9bc2949f457d39b4088c9656c4c9ac15fbbbbaafce8f6d07833"},
-    {file = "pyzmq-23.1.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:8c3abf7eab5b76ae162c4fbb16d514a947fc57fd995b64e5ea8ef8ba3b888a69"},
-    {file = "pyzmq-23.1.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:4fbcd657cda75574fd1315a4c44bd322bc2e219039fb09f146bbe6f8aef039e9"},
-    {file = "pyzmq-23.1.0-cp38-cp38-win32.whl", hash = "sha256:540d7146c3cdc9bbffab039ea067f494eba24d1abe5bd33eb9f963c01e3305d4"},
-    {file = "pyzmq-23.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:8679bb1dd723ecbea03b1f96c98972815775fd8ec756c440a14f289c436c472e"},
-    {file = "pyzmq-23.1.0-cp39-cp39-macosx_10_15_universal2.whl", hash = "sha256:cfee22e072a382b92ee0709dbb8203dabd52d54258051e770d9d2a81b162530b"},
-    {file = "pyzmq-23.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:68e22c5d3be451e87d47f956b397a7823bfbde2176341bc902fba30f96831d7e"},
-    {file = "pyzmq-23.1.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:97d6c676dc97d593625d9fc48154f2ffeabb619a1e6fe8d2a5b53f97e3e9bdee"},
-    {file = "pyzmq-23.1.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:b3bc3cf200aab74f3d758586ac50295214eda496ac6a6636e0c881c5958d9123"},
-    {file = "pyzmq-23.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:48bbc2db041ab28eeee4a3e8ada0ed336640946dd5a8e53dbd3805f9dbdcf0dc"},
-    {file = "pyzmq-23.1.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:67a049bcf967a39993858beed873ed3405536019820922d4efacfe35ab3da51a"},
-    {file = "pyzmq-23.1.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:3955dd5bbbe02f454655296ee36a66c334c7102a29b8458223d168c0380edfd5"},
-    {file = "pyzmq-23.1.0-cp39-cp39-win32.whl", hash = "sha256:8a0f240bf43c29be1bd82d77e602a61c798e9de02e5f8bb7bb414cb814f43236"},
-    {file = "pyzmq-23.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:7e7346b2b33dcd4a2171dd8a9870ae283eec8f6231dcbcf237a0f41e74751a50"},
-    {file = "pyzmq-23.1.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:99dd85f0ca1db8d17a01a25c2bbb7784d25a2d39497c6beddbe96bff74194e04"},
-    {file = "pyzmq-23.1.0-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:563d4281c4dbdf647d93114420151d33f895afc4c46b7115a67a0aa5347e6624"},
-    {file = "pyzmq-23.1.0-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:154de02b15422af28b53d29a02de72121ba503634955017255573fc1f995143d"},
-    {file = "pyzmq-23.1.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:8757c62f7960cd26122f7aaaf86eda1e016fa85734c3777b8054dd334d7dea4d"},
-    {file = "pyzmq-23.1.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:f6c378b435a26fda8996579c0e324b108d2ca0d01b4661503a75634e5155559f"},
-    {file = "pyzmq-23.1.0-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:2e2ac40f7a91c740ec68d6db07ae19ea9259c959333c68bee56ab2c799a67d66"},
-    {file = "pyzmq-23.1.0-pp38-pypy38_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ce8ba5ed8b0a7a203922d61cff45ee6001a41a9359f04f00d055a4e988755569"},
-    {file = "pyzmq-23.1.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:93332c6972e4c91522c4810e907f3aea067424338071161b39cacded022559df"},
-    {file = "pyzmq-23.1.0-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:fc32e7d7f98cac3d8d5153ed2cb583158ae3d446a6efb8e28ccb1c54a09f4169"},
-    {file = "pyzmq-23.1.0-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:86fb683cb9a9c0bb7476988b7957393ecdd22777d87d804442c66e62c99197f9"},
-    {file = "pyzmq-23.1.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:057176dd3f5ccf5aad4abd662d76b6a39bbf799baaf2f39cd4fdaf2eab326e43"},
-    {file = "pyzmq-23.1.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:05ec90a8da618f2398f9d1aa20b18a9ef332992c6ac23e8c866099faad6ef0d6"},
-    {file = "pyzmq-23.1.0.tar.gz", hash = "sha256:1df26aa854bdd3a8341bf199064dd6aa6e240f2eaa3c9fa8d217e5d8b868c73e"},
+    {file = "pyzmq-25.1.2-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:e624c789359f1a16f83f35e2c705d07663ff2b4d4479bad35621178d8f0f6ea4"},
+    {file = "pyzmq-25.1.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:49151b0efece79f6a79d41a461d78535356136ee70084a1c22532fc6383f4ad0"},
+    {file = "pyzmq-25.1.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d9a5f194cf730f2b24d6af1f833c14c10f41023da46a7f736f48b6d35061e76e"},
+    {file = "pyzmq-25.1.2-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:faf79a302f834d9e8304fafdc11d0d042266667ac45209afa57e5efc998e3872"},
+    {file = "pyzmq-25.1.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7f51a7b4ead28d3fca8dda53216314a553b0f7a91ee8fc46a72b402a78c3e43d"},
+    {file = "pyzmq-25.1.2-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:0ddd6d71d4ef17ba5a87becf7ddf01b371eaba553c603477679ae817a8d84d75"},
+    {file = "pyzmq-25.1.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:246747b88917e4867e2367b005fc8eefbb4a54b7db363d6c92f89d69abfff4b6"},
+    {file = "pyzmq-25.1.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:00c48ae2fd81e2a50c3485de1b9d5c7c57cd85dc8ec55683eac16846e57ac979"},
+    {file = "pyzmq-25.1.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:5a68d491fc20762b630e5db2191dd07ff89834086740f70e978bb2ef2668be08"},
+    {file = "pyzmq-25.1.2-cp310-cp310-win32.whl", hash = "sha256:09dfe949e83087da88c4a76767df04b22304a682d6154de2c572625c62ad6886"},
+    {file = "pyzmq-25.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:fa99973d2ed20417744fca0073390ad65ce225b546febb0580358e36aa90dba6"},
+    {file = "pyzmq-25.1.2-cp311-cp311-macosx_10_15_universal2.whl", hash = "sha256:82544e0e2d0c1811482d37eef297020a040c32e0687c1f6fc23a75b75db8062c"},
+    {file = "pyzmq-25.1.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:01171fc48542348cd1a360a4b6c3e7d8f46cdcf53a8d40f84db6707a6768acc1"},
+    {file = "pyzmq-25.1.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bc69c96735ab501419c432110016329bf0dea8898ce16fab97c6d9106dc0b348"},
+    {file = "pyzmq-25.1.2-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3e124e6b1dd3dfbeb695435dff0e383256655bb18082e094a8dd1f6293114642"},
+    {file = "pyzmq-25.1.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7598d2ba821caa37a0f9d54c25164a4fa351ce019d64d0b44b45540950458840"},
+    {file = "pyzmq-25.1.2-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:d1299d7e964c13607efd148ca1f07dcbf27c3ab9e125d1d0ae1d580a1682399d"},
+    {file = "pyzmq-25.1.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:4e6f689880d5ad87918430957297c975203a082d9a036cc426648fcbedae769b"},
+    {file = "pyzmq-25.1.2-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:cc69949484171cc961e6ecd4a8911b9ce7a0d1f738fcae717177c231bf77437b"},
+    {file = "pyzmq-25.1.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:9880078f683466b7f567b8624bfc16cad65077be046b6e8abb53bed4eeb82dd3"},
+    {file = "pyzmq-25.1.2-cp311-cp311-win32.whl", hash = "sha256:4e5837af3e5aaa99a091302df5ee001149baff06ad22b722d34e30df5f0d9097"},
+    {file = "pyzmq-25.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:25c2dbb97d38b5ac9fd15586e048ec5eb1e38f3d47fe7d92167b0c77bb3584e9"},
+    {file = "pyzmq-25.1.2-cp312-cp312-macosx_10_15_universal2.whl", hash = "sha256:11e70516688190e9c2db14fcf93c04192b02d457b582a1f6190b154691b4c93a"},
+    {file = "pyzmq-25.1.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:313c3794d650d1fccaaab2df942af9f2c01d6217c846177cfcbc693c7410839e"},
+    {file = "pyzmq-25.1.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1b3cbba2f47062b85fe0ef9de5b987612140a9ba3a9c6d2543c6dec9f7c2ab27"},
+    {file = "pyzmq-25.1.2-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fc31baa0c32a2ca660784d5af3b9487e13b61b3032cb01a115fce6588e1bed30"},
+    {file = "pyzmq-25.1.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:02c9087b109070c5ab0b383079fa1b5f797f8d43e9a66c07a4b8b8bdecfd88ee"},
+    {file = "pyzmq-25.1.2-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:f8429b17cbb746c3e043cb986328da023657e79d5ed258b711c06a70c2ea7537"},
+    {file = "pyzmq-25.1.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:5074adeacede5f810b7ef39607ee59d94e948b4fd954495bdb072f8c54558181"},
+    {file = "pyzmq-25.1.2-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:7ae8f354b895cbd85212da245f1a5ad8159e7840e37d78b476bb4f4c3f32a9fe"},
+    {file = "pyzmq-25.1.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:b264bf2cc96b5bc43ce0e852be995e400376bd87ceb363822e2cb1964fcdc737"},
+    {file = "pyzmq-25.1.2-cp312-cp312-win32.whl", hash = "sha256:02bbc1a87b76e04fd780b45e7f695471ae6de747769e540da909173d50ff8e2d"},
+    {file = "pyzmq-25.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:ced111c2e81506abd1dc142e6cd7b68dd53747b3b7ae5edbea4578c5eeff96b7"},
+    {file = "pyzmq-25.1.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:7b6d09a8962a91151f0976008eb7b29b433a560fde056ec7a3db9ec8f1075438"},
+    {file = "pyzmq-25.1.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:967668420f36878a3c9ecb5ab33c9d0ff8d054f9c0233d995a6d25b0e95e1b6b"},
+    {file = "pyzmq-25.1.2-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5edac3f57c7ddaacdb4d40f6ef2f9e299471fc38d112f4bc6d60ab9365445fb0"},
+    {file = "pyzmq-25.1.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:0dabfb10ef897f3b7e101cacba1437bd3a5032ee667b7ead32bbcdd1a8422fe7"},
+    {file = "pyzmq-25.1.2-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:2c6441e0398c2baacfe5ba30c937d274cfc2dc5b55e82e3749e333aabffde561"},
+    {file = "pyzmq-25.1.2-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:16b726c1f6c2e7625706549f9dbe9b06004dfbec30dbed4bf50cbdfc73e5b32a"},
+    {file = "pyzmq-25.1.2-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:a86c2dd76ef71a773e70551a07318b8e52379f58dafa7ae1e0a4be78efd1ff16"},
+    {file = "pyzmq-25.1.2-cp36-cp36m-win32.whl", hash = "sha256:359f7f74b5d3c65dae137f33eb2bcfa7ad9ebefd1cab85c935f063f1dbb245cc"},
+    {file = "pyzmq-25.1.2-cp36-cp36m-win_amd64.whl", hash = "sha256:55875492f820d0eb3417b51d96fea549cde77893ae3790fd25491c5754ea2f68"},
+    {file = "pyzmq-25.1.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b8c8a419dfb02e91b453615c69568442e897aaf77561ee0064d789705ff37a92"},
+    {file = "pyzmq-25.1.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8807c87fa893527ae8a524c15fc505d9950d5e856f03dae5921b5e9aa3b8783b"},
+    {file = "pyzmq-25.1.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5e319ed7d6b8f5fad9b76daa0a68497bc6f129858ad956331a5835785761e003"},
+    {file = "pyzmq-25.1.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:3c53687dde4d9d473c587ae80cc328e5b102b517447456184b485587ebd18b62"},
+    {file = "pyzmq-25.1.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:9add2e5b33d2cd765ad96d5eb734a5e795a0755f7fc49aa04f76d7ddda73fd70"},
+    {file = "pyzmq-25.1.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:e690145a8c0c273c28d3b89d6fb32c45e0d9605b2293c10e650265bf5c11cfec"},
+    {file = "pyzmq-25.1.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:00a06faa7165634f0cac1abb27e54d7a0b3b44eb9994530b8ec73cf52e15353b"},
+    {file = "pyzmq-25.1.2-cp37-cp37m-win32.whl", hash = "sha256:0f97bc2f1f13cb16905a5f3e1fbdf100e712d841482b2237484360f8bc4cb3d7"},
+    {file = "pyzmq-25.1.2-cp37-cp37m-win_amd64.whl", hash = "sha256:6cc0020b74b2e410287e5942e1e10886ff81ac77789eb20bec13f7ae681f0fdd"},
+    {file = "pyzmq-25.1.2-cp38-cp38-macosx_10_15_universal2.whl", hash = "sha256:bef02cfcbded83473bdd86dd8d3729cd82b2e569b75844fb4ea08fee3c26ae41"},
+    {file = "pyzmq-25.1.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e10a4b5a4b1192d74853cc71a5e9fd022594573926c2a3a4802020360aa719d8"},
+    {file = "pyzmq-25.1.2-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:8c5f80e578427d4695adac6fdf4370c14a2feafdc8cb35549c219b90652536ae"},
+    {file = "pyzmq-25.1.2-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:5dde6751e857910c1339890f3524de74007958557593b9e7e8c5f01cd919f8a7"},
+    {file = "pyzmq-25.1.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ea1608dd169da230a0ad602d5b1ebd39807ac96cae1845c3ceed39af08a5c6df"},
+    {file = "pyzmq-25.1.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:0f513130c4c361201da9bc69df25a086487250e16b5571ead521b31ff6b02220"},
+    {file = "pyzmq-25.1.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:019744b99da30330798bb37df33549d59d380c78e516e3bab9c9b84f87a9592f"},
+    {file = "pyzmq-25.1.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:2e2713ef44be5d52dd8b8e2023d706bf66cb22072e97fc71b168e01d25192755"},
+    {file = "pyzmq-25.1.2-cp38-cp38-win32.whl", hash = "sha256:07cd61a20a535524906595e09344505a9bd46f1da7a07e504b315d41cd42eb07"},
+    {file = "pyzmq-25.1.2-cp38-cp38-win_amd64.whl", hash = "sha256:eb7e49a17fb8c77d3119d41a4523e432eb0c6932187c37deb6fbb00cc3028088"},
+    {file = "pyzmq-25.1.2-cp39-cp39-macosx_10_15_universal2.whl", hash = "sha256:94504ff66f278ab4b7e03e4cba7e7e400cb73bfa9d3d71f58d8972a8dc67e7a6"},
+    {file = "pyzmq-25.1.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6dd0d50bbf9dca1d0bdea219ae6b40f713a3fb477c06ca3714f208fd69e16fd8"},
+    {file = "pyzmq-25.1.2-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:004ff469d21e86f0ef0369717351073e0e577428e514c47c8480770d5e24a565"},
+    {file = "pyzmq-25.1.2-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c0b5ca88a8928147b7b1e2dfa09f3b6c256bc1135a1338536cbc9ea13d3b7add"},
+    {file = "pyzmq-25.1.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c9a79f1d2495b167119d02be7448bfba57fad2a4207c4f68abc0bab4b92925b"},
+    {file = "pyzmq-25.1.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:518efd91c3d8ac9f9b4f7dd0e2b7b8bf1a4fe82a308009016b07eaa48681af82"},
+    {file = "pyzmq-25.1.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:1ec23bd7b3a893ae676d0e54ad47d18064e6c5ae1fadc2f195143fb27373f7f6"},
+    {file = "pyzmq-25.1.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:db36c27baed588a5a8346b971477b718fdc66cf5b80cbfbd914b4d6d355e44e2"},
+    {file = "pyzmq-25.1.2-cp39-cp39-win32.whl", hash = "sha256:39b1067f13aba39d794a24761e385e2eddc26295826530a8c7b6c6c341584289"},
+    {file = "pyzmq-25.1.2-cp39-cp39-win_amd64.whl", hash = "sha256:8e9f3fabc445d0ce320ea2c59a75fe3ea591fdbdeebec5db6de530dd4b09412e"},
+    {file = "pyzmq-25.1.2-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:a8c1d566344aee826b74e472e16edae0a02e2a044f14f7c24e123002dcff1c05"},
+    {file = "pyzmq-25.1.2-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:759cfd391a0996345ba94b6a5110fca9c557ad4166d86a6e81ea526c376a01e8"},
+    {file = "pyzmq-25.1.2-pp310-pypy310_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7c61e346ac34b74028ede1c6b4bcecf649d69b707b3ff9dc0fab453821b04d1e"},
+    {file = "pyzmq-25.1.2-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4cb8fc1f8d69b411b8ec0b5f1ffbcaf14c1db95b6bccea21d83610987435f1a4"},
+    {file = "pyzmq-25.1.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:3c00c9b7d1ca8165c610437ca0c92e7b5607b2f9076f4eb4b095c85d6e680a1d"},
+    {file = "pyzmq-25.1.2-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:df0c7a16ebb94452d2909b9a7b3337940e9a87a824c4fc1c7c36bb4404cb0cde"},
+    {file = "pyzmq-25.1.2-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:45999e7f7ed5c390f2e87ece7f6c56bf979fb213550229e711e45ecc7d42ccb8"},
+    {file = "pyzmq-25.1.2-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ac170e9e048b40c605358667aca3d94e98f604a18c44bdb4c102e67070f3ac9b"},
+    {file = "pyzmq-25.1.2-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d1b604734bec94f05f81b360a272fc824334267426ae9905ff32dc2be433ab96"},
+    {file = "pyzmq-25.1.2-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:a793ac733e3d895d96f865f1806f160696422554e46d30105807fdc9841b9f7d"},
+    {file = "pyzmq-25.1.2-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:0806175f2ae5ad4b835ecd87f5f85583316b69f17e97786f7443baaf54b9bb98"},
+    {file = "pyzmq-25.1.2-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ef12e259e7bc317c7597d4f6ef59b97b913e162d83b421dd0db3d6410f17a244"},
+    {file = "pyzmq-25.1.2-pp38-pypy38_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ea253b368eb41116011add00f8d5726762320b1bda892f744c91997b65754d73"},
+    {file = "pyzmq-25.1.2-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1b9b1f2ad6498445a941d9a4fee096d387fee436e45cc660e72e768d3d8ee611"},
+    {file = "pyzmq-25.1.2-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:8b14c75979ce932c53b79976a395cb2a8cd3aaf14aef75e8c2cb55a330b9b49d"},
+    {file = "pyzmq-25.1.2-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:889370d5174a741a62566c003ee8ddba4b04c3f09a97b8000092b7ca83ec9c49"},
+    {file = "pyzmq-25.1.2-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9a18fff090441a40ffda8a7f4f18f03dc56ae73f148f1832e109f9bffa85df15"},
+    {file = "pyzmq-25.1.2-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:99a6b36f95c98839ad98f8c553d8507644c880cf1e0a57fe5e3a3f3969040882"},
+    {file = "pyzmq-25.1.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4345c9a27f4310afbb9c01750e9461ff33d6fb74cd2456b107525bbeebcb5be3"},
+    {file = "pyzmq-25.1.2-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:3516e0b6224cf6e43e341d56da15fd33bdc37fa0c06af4f029f7d7dfceceabbc"},
+    {file = "pyzmq-25.1.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:146b9b1f29ead41255387fb07be56dc29639262c0f7344f570eecdcd8d683314"},
+    {file = "pyzmq-25.1.2.tar.gz", hash = "sha256:93f1aa311e8bb912e34f004cf186407a4e90eec4f0ecc0efd26056bf7eda0226"},
 ]
 
 [package.dependencies]
 cffi = {version = "*", markers = "implementation_name == \"pypy\""}
-py = {version = "*", markers = "implementation_name == \"pypy\""}
 
 [[package]]
 name = "rasterio"
@@ -4703,6 +4803,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 
 [extras]
 docs = ["adlfs", "contextily", "datashader", "graphviz", "jupyter-book", "matplotlib", "planetary-computer", "pyogrio", "pystac", "pystac-client", "spatialpandas", "stackstac", "xarray-datatree", "xbatcher", "xpystac", "zarr"]
+lidar = ["laspy"]
 raster = ["xbatcher", "zarr"]
 spatial = ["datashader", "spatialpandas"]
 stac = ["pystac", "pystac-client", "stackstac", "xpystac"]
@@ -4711,4 +4812,4 @@ vector = ["pyogrio"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8, <4.0"
-content-hash = "87b52ac3c816f911e3a68f7b41320f85c00801c70f5db53f49ae3e45bce32d51"
+content-hash = "e9176c13ab57c1f06878fbb0e84457d536c55f210f1685c4fa0ac5cf04b136bc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ rioxarray = ">=0.10.0"
 torchdata = ">=0.4.0"
 # Optional
 datashader = {version = ">=0.14.0", optional = true}
+laspy = {version = ">=2.5.0", extras = ["lazrs"], optional = true}
 pyogrio = {version = ">=0.4.0", extras = ["geopandas"], optional = true}
 pystac = {version=">=1.4.0", optional=true}
 pystac-client = {version = ">=0.4.0", optional = true}
@@ -75,6 +76,9 @@ docs = [
     "xbatcher",
     "xpystac",
     "zarr"
+]
+lidar = [
+    "laspy",
 ]
 raster = [
     "xbatcher",

--- a/zen3geo/datapipes/__init__.py
+++ b/zen3geo/datapipes/__init__.py
@@ -9,6 +9,7 @@ from zen3geo.datapipes.datashader import (
 from zen3geo.datapipes.geopandas import (
     GeoPandasRectangleClipperIterDataPipe as GeoPandasRectangleClipper,
 )
+from zen3geo.datapipes.laspy import LaspyReaderIterDataPipe as LaspyReader
 from zen3geo.datapipes.pyogrio import PyogrioReaderIterDataPipe as PyogrioReader
 from zen3geo.datapipes.pystac import PySTACItemReaderIterDataPipe as PySTACItemReader
 from zen3geo.datapipes.pystac_client import (

--- a/zen3geo/datapipes/laspy.py
+++ b/zen3geo/datapipes/laspy.py
@@ -1,0 +1,90 @@
+"""
+DataPipes for :doc:`laspy <laspy:index>`.
+"""
+import io
+from typing import Any, Dict, Iterator, Optional
+
+try:
+    import laspy
+except ImportError:
+    laspy = None
+from torchdata.datapipes import functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe
+from torchdata.datapipes.utils import StreamWrapper
+
+
+@functional_datapipe("read_from_laspy")
+class LaspyReaderIterDataPipe(IterDataPipe[StreamWrapper]):
+    """
+    Takes LAS/LAZ files from local disk or an :py:class:`io.BytesIO` stream (as long as
+    they can be read by laspy) and yields :py:class:`laspy.lasdata.LasData` objects
+    (functional name: ``read_from_laspy``).
+
+    Parameters
+    ----------
+    source_datapipe : IterDataPipe[str]
+        A DataPipe that contains filepaths or an :py:class:`io.BytesIO` stream to point
+        cloud files in LAS or LAZ format.
+
+    kwargs : Optional
+        Extra keyword arguments to pass to :py:func:`laspy.read`.
+
+    Yields
+    ------
+    stream_obj : laspy.lasdata.LasData
+        A :py:class:`laspy.lasdata.LasData` object containing the point cloud data.
+
+    Raises
+    ------
+    ModuleNotFoundError
+        If ``laspy`` is not installed. See
+        :doc:`install instructions for laspy <laspy:installation>`, (e.g. via
+        ``pip install laspy[lazrs]``) before using this class.
+
+    Example
+    -------
+    >>> import pytest
+    >>> laspy = pytest.importorskip("laspy")
+    ...
+    >>> from torchdata.datapipes.iter import IterableWrapper
+    >>> from zen3geo.datapipes import LaspyReader
+    ...
+    >>> # Read in LAZ data using DataPipe
+    >>> file_url: str = "https://opentopography.s3.sdsc.edu/pc-bulk/NZ19_Wellington/CL2_BQ31_2019_1000_2138.laz"
+    >>> dp = IterableWrapper(iterable=[file_url])
+    >>> _, dp_stream = dp.read_from_http().unzip(sequence_length=2)
+    >>> dp_laspy = dp_stream.read_from_laspy()
+    ...
+    >>> # Loop or iterate over the DataPipe stream
+    >>> it = iter(dp_laspy)
+    >>> lasdata = next(it)
+    >>> lasdata.header
+    <LasHeader(1.4, <PointFormat(6, 0 bytes of extra dims)>)>
+    >>> lasdata.xyz
+    array([[ 1.74977156e+06,  5.42749877e+06, -7.24000000e-01],
+           [ 1.74977152e+06,  5.42749846e+06, -7.08000000e-01],
+           [ 1.74977148e+06,  5.42749815e+06, -7.00000000e-01],
+           ...,
+           [ 1.74976026e+06,  5.42756798e+06, -4.42000000e-01],
+           [ 1.74976029e+06,  5.42756829e+06, -4.17000000e-01],
+           [ 1.74976032e+06,  5.42756862e+06, -4.04000000e-01]])
+    """
+
+    def __init__(
+        self, source_datapipe: IterDataPipe[str], **kwargs: Optional[Dict[str, Any]]
+    ) -> None:
+        if laspy is None:
+            raise ModuleNotFoundError(
+                "Package `laspy` is required to be installed to use this datapipe. "
+                "Please use `pip install laspy` or "
+                "`conda install -c conda-forge laspy` to install the package"
+            )
+        self.source_datapipe: IterDataPipe[str] = source_datapipe
+        self.kwargs = kwargs
+
+    def __iter__(self) -> Iterator[StreamWrapper]:
+        for lazstream in self.source_datapipe:
+            yield StreamWrapper(laspy.read(source=lazstream, **self.kwargs))
+
+    def __len__(self) -> int:
+        return len(self.source_datapipe)

--- a/zen3geo/datapipes/laspy.py
+++ b/zen3geo/datapipes/laspy.py
@@ -1,7 +1,6 @@
 """
 DataPipes for :doc:`laspy <laspy:index>`.
 """
-import io
 from typing import Any, Dict, Iterator, Optional
 
 try:
@@ -22,9 +21,9 @@ class LaspyReaderIterDataPipe(IterDataPipe[StreamWrapper]):
 
     Parameters
     ----------
-    source_datapipe : IterDataPipe[str]
+    source_datapipe : IterDataPipe[str, io.BytesIO]
         A DataPipe that contains filepaths or an :py:class:`io.BytesIO` stream to point
-        cloud files in LAS or LAZ format.
+        cloud data such as LAS, LAZ, COPC, etc.
 
     kwargs : Optional
         Extra keyword arguments to pass to :py:func:`laspy.read`.

--- a/zen3geo/tests/test_datapipes_laspy.py
+++ b/zen3geo/tests/test_datapipes_laspy.py
@@ -1,0 +1,119 @@
+"""
+Tests for laspy datapipes.
+"""
+import tempfile
+import urllib
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+from torchdata.datapipes.iter import IterableWrapper
+
+from zen3geo.datapipes import LaspyReader
+
+laspy = pytest.importorskip("laspy")
+
+
+# %%
+def test_laspy_reader_las_local():
+    """
+    Ensure that LaspyReader works to read in a LAS file (on disk) and outputs a
+    laspy.lasdata.LasData object.
+    """
+    with tempfile.NamedTemporaryFile(suffix=".las") as tmpfile:
+        urllib.request.urlretrieve(
+            url="https://github.com/laz-rs/laz-rs/raw/0.8.3/tests/data/point-time-color.las",
+            filename=tmpfile.name,
+        )
+        dp = IterableWrapper(iterable=[tmpfile.name])
+
+        # Using class constructors
+        dp_laspy = LaspyReader(source_datapipe=dp)
+        # Using functional form (recommended)
+        dp_laspy = dp.read_from_laspy()
+
+        assert len(dp_laspy) == 1
+        it = iter(dp_laspy)
+        lasdata = next(it)
+
+    assert lasdata.header.version == laspy.header.Version(major=1, minor=2)
+    assert lasdata.header.point_format == laspy.point.PointFormat(point_format_id=3)
+    assert lasdata.points.array.shape == (1065,)
+    assert lasdata.xyz.shape == (1065, 3)
+    npt.assert_allclose(
+        actual=lasdata.xyz.mean(axis=0),
+        desired=[494494.6635117371, 4878134.831230047, 132.31299530516432],
+    )
+    npt.assert_allclose(actual=np.unique(lasdata.classification.array), desired=[1, 2])
+
+
+def test_laspy_reader_laz_http():
+    """
+    Ensure that LaspyReader works to read in a LAZ file (from a HTTP byte stream)
+    and outputs a laspy.lasdata.LasData object.
+    """
+    file_url: str = "https://github.com/laz-rs/laz-rs/raw/0.8.3/tests/data/point-version-1-point-wise.laz"
+    dp = IterableWrapper(iterable=[file_url])
+    _, dp_stream = (
+        dp.read_from_http()
+        .read_from_stream()
+        .set_length(length=1)
+        .unzip(sequence_length=2)
+    )
+
+    # Using class constructors
+    dp_laspy = LaspyReader(source_datapipe=dp_stream)
+    # Using functional form (recommended)
+    dp_laspy = dp_stream.read_from_laspy()
+
+    assert len(dp_laspy) == 1
+    it = iter(dp_laspy)
+    lasdata = next(it)
+
+    assert lasdata.header.version == laspy.header.Version(major=1, minor=0)
+    assert lasdata.header.point_format == laspy.point.PointFormat(point_format_id=0)
+    assert lasdata.points.array.shape == (11781,)
+    assert lasdata.xyz.shape == (11781, 3)
+    npt.assert_allclose(
+        actual=lasdata.xyz.mean(axis=0),
+        desired=[2483799.026934895, 366405.56612511666, 1511.9428214922332],
+    )
+    npt.assert_allclose(
+        actual=np.unique(lasdata.classification), desired=[1, 2, 8, 9, 12, 15]
+    )
+
+
+def test_laspy_reader_copc_http():
+    """
+    Ensure that LaspyReader works to read in a COPC file (from a HTTP byte stream) and
+    outputs a laspy.lasdata.LasData object.
+    """
+    file_url: str = (
+        "https://github.com/laspy/laspy/raw/2.5.3/tests/data/simple_with_page.copc.laz"
+    )
+    dp = IterableWrapper(iterable=[file_url])
+    _, dp_stream = (
+        dp.read_from_http()
+        .read_from_stream()
+        .set_length(length=1)
+        .unzip(sequence_length=2)
+    )
+
+    # Using class constructors
+    dp_laspy = LaspyReader(source_datapipe=dp_stream)
+    # Using functional form (recommended)
+    dp_laspy = dp_stream.read_from_laspy()
+
+    assert len(dp_laspy) == 1
+    it = iter(dp_laspy)
+    lasdata = next(it)
+
+    assert lasdata.header.version == laspy.header.Version(major=1, minor=4)
+    assert lasdata.header.point_format == laspy.point.PointFormat(point_format_id=7)
+    assert lasdata.points.array.shape == (1065,)
+    assert lasdata.xyz.shape == (1065, 3)
+    npt.assert_allclose(
+        actual=lasdata.xyz.mean(axis=0),
+        desired=[637296.7351830985, 851249.5384882629, 434.0978403755869],
+    )
+    npt.assert_allclose(actual=np.unique(lasdata.classification), desired=[1, 2])


### PR DESCRIPTION
An iterable-style [DataPipe](https://github.com/pytorch/data/tree/v0.7.0#what-are-datapipes) for point cloud data!

I/O handled using [laspy](https://laspy.readthedocs.io/en/latest/api/laspy.lasdata.html#laspy.lasdata.LasData).

**Preview** at https://zen3geo--137.org.readthedocs.build/en/137/api.html#module-zen3geo.datapipes.laspy

Usage:

```python
from torchdata.datapipes.iter import IterableWrapper
from zen3geo.datapipes import LaspyReader

# Read in LAZ data using DataPipe
file_url: str = "https://opentopography.s3.sdsc.edu/pc-bulk/NZ19_Wellington/CL2_BQ31_2019_1000_2138.laz"
dp = IterableWrapper(iterable=[file_url])
_, dp_stream = dp.read_from_http().unzip(sequence_length=2)
dp_laspy = dp_stream.read_from_laspy()

# Loop or iterate over the DataPipe stream
it = iter(dp_laspy)
lasdata = next(it)
lasdata.header
# <LasHeader(1.4, <PointFormat(6, 0 bytes of extra dims)>)>
lasdata.xyz
# array([[ 1.74977156e+06,  5.42749877e+06, -7.24000000e-01],
#        [ 1.74977152e+06,  5.42749846e+06, -7.08000000e-01],
#        [ 1.74977148e+06,  5.42749815e+06, -7.00000000e-01],
#        ...,
#        [ 1.74976026e+06,  5.42756798e+06, -4.42000000e-01],
#        [ 1.74976029e+06,  5.42756829e+06, -4.17000000e-01],
#        [ 1.74976032e+06,  5.42756862e+06, -4.04000000e-01]])
```


Note that since `laspy` is made an optional dependency, users would need to do `pip install zen3geo[lidar]` to install the extra 'lidar' packages that includes `laspy[lazrs]`.

TODO:
- [x] Add `laspy` as an optional dependency
- [x] Initial implementation of `LaspyReaderIterDataPipe`
- [x] Add unit tests to read COPC/LAS/LAZ files
- [ ] Properly document new `lidar` extras